### PR TITLE
Skale 1019 fix consensus standalone tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(bls ${sourses_bls} ${headers_bls})
 
 target_compile_options(bls PUBLIC -Wno-error=sign-compare -Wno-error=reorder -Wno-error=unused-but-set-variable)
 
+
 find_package(Boost REQUIRED program_options system)
 
 find_package(OpenSSL REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.5.1)
 
 project(libBLS)
 
+
+set(HUNTER_ENABLED OFF)
+
 option(BUILD_TESTS "Build tests" ON)
 
 if(BUILD_TESTS)


### PR DESCRIPTION
It is a small change to fix build if the upper project is using hunter
