### PR TITLE
SKALE-1565-fix-boost-build

### DIFF
--- a/deps/build.sh
+++ b/deps/build.sh
@@ -473,7 +473,7 @@ then
 		sed -i -e 's#using gcc ;#using gcc : arm : /usr/local/toolchains/gcc7.2-arm/bin/arm-linux-gnueabihf-g++ ;#g' project-config.jam
 		./b2 $CONF_CROSSCOMPILING_OPTS_BOOST cxxflags=-fPIC cflags=-fPIC $PARALLEL_MAKE_OPTIONS --prefix=$INSTALL_ROOT --layout=system variant=debug link=static threading=multi install
 		else
-		./b2 cxxflags=-fPIC cflags=-fPIC $PARALLEL_MAKE_OPTIONS --prefix=$INSTALL_ROOT --layout=system variant=debug link=static threading=multi install
+		./b2 cxxflags=-fPIC cxxstd=14 cflags=-fPIC $PARALLEL_MAKE_OPTIONS --prefix=$INSTALL_ROOT --layout=system variant=debug link=static threading=multi install
 	fi
 		cd ..
 		cd $SOURCES_ROOT


### PR DESCRIPTION
low risk
fixing consensus's cmake error `undefined reference to `boost::system::detail::system_category_instance'`