### PR TITLE
SKALE-1485 Build system is switched to gcc/g++ 9.2, also supports 8.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,16 @@ matrix:
           env:
             - BUILDING_FOR_OS=linux
             - CMAKE_BUILD_FLAGS="-DCOVERAGE=ON"
-            - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+            - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
             - CPU_COUNT=$(nproc)
             - NIGHTLY_BUILD_FLAGS="valgrind --leak-check=yes"
           addons:
               apt:
+                  sources:
+                      - ubuntu-toolchain-r-test
                   packages:
-                      - g++-7
+                      - gcc-9
+                      - g++-9
                       - clang-format-6.0
                       - valgrind
                       - gawk
@@ -61,12 +64,15 @@ matrix:
           env:
             - BUILDING_FOR_OS=linux
             - CMAKE_BUILD_FLAGS=""
-            - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+            - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
             - CPU_COUNT=$(nproc)
           addons:
               apt:
+                  sources:
+                      - ubuntu-toolchain-r-test
                   packages:
-                      - g++-7
+                      - gcc-9
+                      - g++-9
                       - clang-format-6.0
                       - valgrind
                       - gawk
@@ -83,12 +89,15 @@ matrix:
             - PYTHON=3.6
             - BUILDING_FOR_OS=linux
             - CMAKE_BUILD_FLAGS="-DBUILD_WITH_FPIC=ON"
-            - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+            - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
             - CPU_COUNT=$(nproc)
           addons:
               apt:
+                  sources:
+                      - ubuntu-toolchain-r-test
                   packages:
-                      - g++-7
+                      - gcc-9
+                      - g++-9
                       - clang-format-6.0
                       - valgrind
                       - gawk
@@ -145,7 +154,7 @@ script:
     - mkdir -p build
     - cd build
     - cmake $CMAKE_BUILD_FLAGS ..
-    - if [ "$TRAVIS_OS_NAME" != "osx" ]; then make format-check || travis_terminate 1; fi
+    - if [ "$TRAVIS_OS_NAME" != "osx" ]; then make bls-format-check || travis_terminate 1; fi
     - cmake --build . -- -j$CPU_COUNT
     - cd ..
     - echo "========================================= script (2)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ matrix:
               - sudo python -m pip install pyopenssl ndg-httpsclient pyasn1
               - sudo python -m pip install requests[security]
               - sudo python -m pip install codecov --ignore-installed
+              - echo "========================================= before_script (setting up alternatives)"
+              - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 900 --slave /usr/bin/g++ g++ /usr/bin/g++-9 --slave /usr/bin/gcov gcov /usr/bin/gcov-9
               - echo "========================================= before_script (codecov installed)"
               - mkdir -p build
               - cd build
@@ -118,6 +120,8 @@ matrix:
               - sudo apt-get install python3-pip
               - sudo apt-get install python3-setuptools
               - python3.6 -m pip install coincurve
+              - echo "========================================= before_script (setting up alternatives)"
+              - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 900 --slave /usr/bin/g++ g++ /usr/bin/g++-9 --slave /usr/bin/gcov gcov /usr/bin/gcov-9
           after_success:
               - cd python
               - echo "========================================= after_success (dkg)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,9 @@ matrix:
               - mkdir -p build
               - cd build
               - cd ..
+              - echo "========================================= before_script (installing latest lcov - before)"
+              - git clone git clone https://github.com/linux-test-project/lcov.git && cd lcov && sudo make install && cd .. && lcov --version
+              - echo "========================================= before_script (installing latest lcov - after)"
           after_success:
               - cd build
               - echo "========================================= after_success (coverage)"
@@ -79,7 +82,6 @@ matrix:
                       - valgrind
                       - gawk
                       - sed
-                      - lcov
                       - yasm
                       - texinfo
                       - shtool

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
               - cd build
               - cd ..
               - echo "========================================= before_script (installing latest lcov - before)"
-              - git clone git clone https://github.com/linux-test-project/lcov.git && cd lcov && sudo make install && cd .. && lcov --version
+              - git clone https://github.com/linux-test-project/lcov.git && cd lcov && sudo make install && cd .. && lcov --version
               - echo "========================================= before_script (installing latest lcov - after)"
           after_success:
               - cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@ set( CMAKE_CXX_STANDARD 17 )
 project(libBLS)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
-        message(FATAL_ERROR "Require at least gcc-7.0")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+        message(FATAL_ERROR "Require at least gcc-9.0")
     endif()
 endif()
 
@@ -55,11 +55,11 @@ if(COVERAGE)
 	set(CMAKE_EXE_LINKER_FLAGS "--coverage ${CMAKE_EXE_LINKER_FLAGS}")
 endif()
 
-set( CLANG_FORMAT_EXCLUDE_PATTERNS
+set( BLS_CLANG_FORMAT_EXCLUDE_PATTERNS
     ${CMAKE_BINARY_DIR}
     ${DEPS_SOURCES_ROOT}
     )
-include( FindClangFormat )
+include( ./cmake/FindClangFormat.cmake )
 
 set(sourses_bls
 		bls/bls.cpp
@@ -199,3 +199,5 @@ if(NOT SKALE_SKIP_INSTALLING_DIRECTIVES)
 	install( TARGETS bls_glue DESTINATION bin )
 	install( TARGETS verify_bls DESTINATION bin )
 endif()
+
+

--- a/cmake/FindClangFormat.cmake
+++ b/cmake/FindClangFormat.cmake
@@ -57,5 +57,5 @@ if( ( NOT DEFINED CLANG_FORMAT_BIN_NAME ) OR ( "${CLANG_FORMAT_BIN_NAME}" STREQU
         message( INFO " - clang-format not found and not specified - will skip setting up format targets" )
 else()
         # A CMake script to find all source files and setup clang-format targets for them
-        include( clang-format )
+        include( ./cmake/clang-format.cmake )
 endif()

--- a/cmake/clang-format.cmake
+++ b/cmake/clang-format.cmake
@@ -1,57 +1,59 @@
 # A CMake script to find all source files and setup clang-format targets for them
 
 # Find all source files
-set(CLANG_FORMAT_CXX_FILE_EXTENSIONS ${CLANG_FORMAT_CXX_FILE_EXTENSIONS} *.cpp *.h *.cxx *.hxx *.hpp *.cc *.ipp)
-file(GLOB_RECURSE ALL_SOURCE_FILES ${CLANG_FORMAT_CXX_FILE_EXTENSIONS})
+set(BLS_CLANG_FORMAT_CXX_FILE_EXTENSIONS ${BLS_CLANG_FORMAT_CXX_FILE_EXTENSIONS} *.cpp *.h *.cxx *.hxx *.hpp *.cc *.ipp)
+file(GLOB_RECURSE BLS_ALL_SOURCE_FILES ${BLS_CLANG_FORMAT_CXX_FILE_EXTENSIONS})
 
 # Don't include some common build folders
-set(CLANG_FORMAT_EXCLUDE_PATTERNS ${CLANG_FORMAT_EXCLUDE_PATTERNS} "/CMakeFiles/" "cmake")
+set(BLS_CLANG_FORMAT_EXCLUDE_PATTERNS ${BLS_CLANG_FORMAT_EXCLUDE_PATTERNS} "/CMakeFiles/" "cmake")
 
 # get all project files file
-foreach (EXCLUDE_PATTERN ${CLANG_FORMAT_EXCLUDE_PATTERNS})
-    list(FILTER ALL_SOURCE_FILES EXCLUDE REGEX ${EXCLUDE_PATTERN})
+foreach (BLS_EXCLUDE_PATTERN ${BLS_CLANG_FORMAT_EXCLUDE_PATTERNS})
+    list(FILTER BLS_ALL_SOURCE_FILES EXCLUDE REGEX ${BLS_EXCLUDE_PATTERN})
 endforeach()
 
-add_custom_target(format
-    COMMENT "Running clang-format to change files"
+add_custom_target( bls-format
+    COMMENT "Running clang-format to change BLS files"
     COMMAND ${CLANG_FORMAT_BIN}
     -style=file
     -i
-    ${ALL_SOURCE_FILES}
+    ${BLS_ALL_SOURCE_FILES}
 )
 
 
-add_custom_target(format-check
-    COMMENT "Checking clang-format changes"
+add_custom_target( bls-format-check
+    COMMENT "Checking clang-format changes in BLS"
     # Use ! to negate the result for correct output
     COMMAND !
     ${CLANG_FORMAT_BIN}
     -style=file
     -output-replacements-xml
-    ${ALL_SOURCE_FILES}
+    ${BLS_ALL_SOURCE_FILES}
     | grep -q "replacement offset"
 )
 
 # Get the path to this file
 get_filename_component(_clangcheckpath ${CMAKE_CURRENT_LIST_FILE} PATH)
 # have at least one here by default
-set(CHANGED_FILE_EXTENSIONS ".cpp")
-foreach(EXTENSION ${CLANG_FORMAT_CXX_FILE_EXTENSIONS})
-    set(CHANGED_FILE_EXTENSIONS "${CHANGED_FILE_EXTENSIONS},${EXTENSION}" )
+set(BLS_CHANGED_FILE_EXTENSIONS ".cpp")
+foreach(EXTENSION ${BLS_CLANG_FORMAT_CXX_FILE_EXTENSIONS})
+    set(BLS_CHANGED_FILE_EXTENSIONS "${BLS_CHANGED_FILE_EXTENSIONS},${EXTENSION}" )
 endforeach()
 
-set(EXCLUDE_PATTERN_ARGS)
-foreach(EXCLUDE_PATTERN ${CLANG_FORMAT_EXCLUDE_PATTERNS})
-    list(APPEND EXCLUDE_PATTERN_ARGS "--exclude=${EXCLUDE_PATTERN}")
+set(BLS_EXCLUDE_PATTERN_ARGS)
+foreach(BLS_EXCLUDE_PATTERN ${BLS_CLANG_FORMAT_EXCLUDE_PATTERNS})
+    list(APPEND BLS_EXCLUDE_PATTERN_ARGS "--exclude=${BLS_EXCLUDE_PATTERN}")
 endforeach()
 
 # call the script to chech changed files in git
-add_custom_target(format-check-changed
-    COMMENT "Checking changed files in git"
+add_custom_target( bls-format-check-changed
+    COMMENT "Checking changed BLS files in git"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMAND ${_clangcheckpath}/../scripts/clang-format-check-changed.py 
-    --file-extensions \"${CHANGED_FILE_EXTENSIONS}\"
-    ${EXCLUDE_PATTERN_ARGS}
+    --file-extensions \"${BLS_CHANGED_FILE_EXTENSIONS}\"
+    ${BLS_EXCLUDE_PATTERN_ARGS}
     --clang-format-bin ${CLANG_FORMAT_BIN}
 )
+
+
 

--- a/deps/build.sh
+++ b/deps/build.sh
@@ -262,17 +262,34 @@ then
 	else
 		if [ "$UNIX_SYSTEM_NAME" = "Linux" ];
 		then
-			export CC=`which gcc-7`
-			if [ -z "${CC}" ];
-			then
-				export CC=`which gcc`
-			fi
-			export CXX=`which g++-7`
-			if [ -z "${CXX}" ];
-			then
-				export CXX=`which g++`
-			fi
-		else
+            export CC=`which gcc-9`
+            if [ -z "${CC}" ];
+            then
+                export CC=`which gcc-8`
+                if [ -z "${CC}" ];
+                then
+                    export CC=`which gcc-7`
+                    if [ -z "${CC}" ];
+                    then
+                        export CC=`which gcc`
+                    fi
+                fi
+            fi
+            ###
+            export CXX=`which g++-9`
+            if [ -z "${CXX}" ];
+            then
+                export CXX=`which g++-8`
+                if [ -z "${CXX}" ];
+                then
+                    export CXX=`which g++-7`
+                    if [ -z "${CXX}" ];
+                    then
+                        export CXX=`which g++`
+                    fi
+                fi
+            fi
+        else
 			export CC=`which gcc`
 			export CXX=`which g++`
 		fi

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-# encoding: utf-8
+# encoding: utf-9
 
 import os
 from distutils.core import setup, Extension
 
 strCompilerCommonFlagsSuffix = " -fpermissive -fPIC -std=c++11 -Wno-error=parentheses -Wno-error=char-subscripts"
-os.environ["CC" ] = "gcc-7" + strCompilerCommonFlagsSuffix
-os.environ["CXX"] = "g++-7" + strCompilerCommonFlagsSuffix
+os.environ["CC" ] = "gcc-9" + strCompilerCommonFlagsSuffix
+os.environ["CXX"] = "g++-9" + strCompilerCommonFlagsSuffix
 os.environ["LD" ] = "ld" + strCompilerCommonFlagsSuffix
 
 dkgpython_module = Extension('dkgpython',

--- a/test/unit_tests_dkg.cpp
+++ b/test/unit_tests_dkg.cpp
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE( PolynomialValue ) {
 
     try {
         value = obj.PolynomialValue( polynomial, 5 );
-    } catch ( std::runtime_error & ) {
+    } catch ( std::runtime_error& ) {
         is_exception_caught = true;
     }
 

--- a/test/unit_tests_dkg.cpp
+++ b/test/unit_tests_dkg.cpp
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE( PolynomialValue ) {
 
     try {
         value = obj.PolynomialValue( polynomial, 5 );
-    } catch ( std::runtime_error ) {
+    } catch ( std::runtime_error & ) {
         is_exception_caught = true;
     }
 


### PR DESCRIPTION
**THIS IS INVESTIGATION, NO NEED TO MERGE BEFORE RELEASE**

- gcc/g++ 9 and 8 support
- renamed "format" -> "bls-format" in make build targets to avoid conflict with same targets in skaled when using latest cmake 3.17.1
- no new tests needed

To install gcc-9:

sudo add-apt-repository ppa:ubuntu-toolchain-r/test
sudo apt-get update
sudo apt-get install gcc-9 g++-9
gcc-9 --version; g++-9 --version
sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 900 --slave /usr/bin/g++ g++ /usr/bin/g++-9 --slave /usr/bin/gcov gcov /usr/bin/gcov-9/usr/bin/g++-9
gcc --version; g++ --version

To replace your current cmake with latest 3.17.1:

sudo apt purge --auto-remove cmake
sudo apt update
sudo apt install snapd
sudo snap install cmake --classic
sudo ldconfig
cmake --version
