### PR TITLE
feature/SKALE-2932 variable renaming

### DIFF
--- a/tools/dkg_glue.cpp
+++ b/tools/dkg_glue.cpp
@@ -135,13 +135,13 @@ void GenerateSecretKeys( const size_t t, const size_t n, const std::vector< std:
 
         libff::alt_bn128_G2 publ_key = dkg_instance.GetPublicKeyFromSecretKey( secret_key[i] );
         publ_key.to_affine_coordinates();
-        BLS_key_file["insecureBLSPublicKey0"] =
+        BLS_key_file["BLSPublicKey0"] =
             BLSutils::ConvertToString< libff::alt_bn128_Fq >( publ_key.X.c0 );
-        BLS_key_file["insecureBLSPublicKey1"] =
+        BLS_key_file["BLSPublicKey1"] =
             BLSutils::ConvertToString< libff::alt_bn128_Fq >( publ_key.X.c1 );
-        BLS_key_file["insecureBLSPublicKey2"] =
+        BLS_key_file["BLSPublicKey2"] =
             BLSutils::ConvertToString< libff::alt_bn128_Fq >( publ_key.Y.c0 );
-        BLS_key_file["insecureBLSPublicKey3"] =
+        BLS_key_file["BLSPublicKey3"] =
             BLSutils::ConvertToString< libff::alt_bn128_Fq >( publ_key.Y.c1 );
 
         if ( g_b_verbose_mode ) {
@@ -151,13 +151,13 @@ void GenerateSecretKeys( const size_t t, const size_t n, const std::vector< std:
 
     common_public_key.to_affine_coordinates();
     nlohmann::json public_key_json;
-    public_key_json["insecureCommonBLSPublicKey0"] =
+    public_key_json["commonBLSPublicKey0"] =
         BLSutils::ConvertToString< libff::alt_bn128_Fq >( common_public_key.X.c0 );
-    public_key_json["insecureCommonBLSPublicKey1"] =
+    public_key_json["commonBLSPublicKey1"] =
         BLSutils::ConvertToString< libff::alt_bn128_Fq >( common_public_key.X.c1 );
-    public_key_json["insecureCommonBLSPublicKey2"] =
+    public_key_json["commonBLSPublicKey2"] =
         BLSutils::ConvertToString< libff::alt_bn128_Fq >( common_public_key.Y.c0 );
-    public_key_json["insecureCommonBLSPublicKey3"] =
+    public_key_json["commonBLSPublicKey3"] =
         BLSutils::ConvertToString< libff::alt_bn128_Fq >( common_public_key.Y.c1 );
 
     std::ofstream outfile_pk( "common_public_key.json" );

--- a/tools/dkg_key_gen.cpp
+++ b/tools/dkg_key_gen.cpp
@@ -42,7 +42,7 @@ void KeysToJson( std::shared_ptr< BLSPrivateKeyShare > skey_ptr, size_t num_sign
     keys_json["insecureBLSPrivateKey"] = *skey_ptr->toString();
     BLSPublicKeyShare pkey( *skey_ptr->getPrivateKey(), num_signed, num_all );
     std::shared_ptr< std::vector< std::string > > pkey_ptr = pkey.toString();
-    std::string pkey_name = "insecureBLSPublicKey";
+    std::string pkey_name = "BLSPublicKey";
     for ( size_t i = 0; i < 4; i++ ) {
         keys_json[pkey_name + std::to_string( i )] = pkey_ptr->at( i );
     }
@@ -54,7 +54,7 @@ void KeysToJson( std::shared_ptr< BLSPrivateKeyShare > skey_ptr, size_t num_sign
 
 void CommonPkeyToJson( std::shared_ptr< BLSPublicKey > common_pkey_ptr ) {
     nlohmann::json keys_json;
-    std::string pkey_name = "insecureCommonBLSPublicKey";
+    std::string pkey_name = "commonBLSPublicKey";
     std::shared_ptr< std::vector< std::string > > common_pkey_str = common_pkey_ptr->toString();
     for ( size_t i = 0; i < 4; ++i ) {
         keys_json[pkey_name + std::to_string( i )] = common_pkey_str->at( i );

--- a/tools/verify_bls.cpp
+++ b/tools/verify_bls.cpp
@@ -111,14 +111,14 @@ void Verify( const size_t t, const size_t n, std::istream& sign_file, int j = -1
         pk_file >> pk_in;
 
         for ( size_t i = 0; i < 4; i++ ) {
-            pkey_str.push_back( pk_in["insecureCommonBLSPublicKey" + std::to_string( i )] );
+            pkey_str.push_back( pk_in["commonBLSPublicKey" + std::to_string( i )] );
         }
     } else {
         std::ifstream pk_file( "BLS_keys" + std::to_string( j ) + ".json" );
         pk_file >> pk_in;
 
         for ( size_t i = 0; i < 4; i++ ) {
-            pkey_str.push_back( pk_in["insecureBLSPublicKey" + std::to_string( i )] );
+            pkey_str.push_back( pk_in["BLSPublicKey" + std::to_string( i )] );
         }
     }
 


### PR DESCRIPTION
onfiguration parameter and variable name renaming.

Shell variables:

CHAIN_NAME_MAINNET -> CHAIN_NAME_ETHEREUM
MAINNET_PROXY_PATH -> ETHEREUM_PROXY_PATH
INSECURE_PRIVATE_KEY_FOR_MAINNET -> INSECURE_PRIVATE_KEY_FOR_ETHEREUM
ACCOUNT_FOR_MAINNET -> ACCOUNT_FOR_ETHEREUM
NETWORK_FOR_MAINNET -> NETWORK_FOR_ETHEREUM
CID_MAINNET -> CID_ETHEREUM
URL_W3_MAIN_NET -> URL_W3_ETHEREUM

Config JSON variables:

insecureCommonBLSPublicKey -> commonBLSPublicKey
insecureBLSPublicKey -> BLSPublicKey