### PR TITLE
Resolve out_of_range exception in BLSPublicKey constructor

### DIFF
--- a/bls/BLSPublicKey.cpp
+++ b/bls/BLSPublicKey.cpp
@@ -167,8 +167,8 @@ BLSPublicKey::BLSPublicKey(
     libff::alt_bn128_G2 key = libff::alt_bn128_G2::zero();
     size_t i = 0;
     for ( auto&& item : *koefs_pkeys_map ) {
-        if(i < _requiredSigners) {
-            key = key + lagrangeCoeffs.at(i) * (*item.second->getPublicKey());
+        if ( i < _requiredSigners ) {
+            key = key + lagrangeCoeffs.at( i ) * ( *item.second->getPublicKey() );
             i++;
         }
         else {

--- a/bls/BLSPublicKey.cpp
+++ b/bls/BLSPublicKey.cpp
@@ -170,8 +170,7 @@ BLSPublicKey::BLSPublicKey(
         if ( i < _requiredSigners ) {
             key = key + lagrangeCoeffs.at( i ) * ( *item.second->getPublicKey() );
             i++;
-        }
-        else {
+        } else {
             break;
         }
     }

--- a/bls/BLSPublicKey.cpp
+++ b/bls/BLSPublicKey.cpp
@@ -167,8 +167,13 @@ BLSPublicKey::BLSPublicKey(
     libff::alt_bn128_G2 key = libff::alt_bn128_G2::zero();
     size_t i = 0;
     for ( auto&& item : *koefs_pkeys_map ) {
-        key = key + lagrangeCoeffs.at( i ) * ( *item.second->getPublicKey() );
-        i++;
+        if(i < _requiredSigners) {
+            key = key + lagrangeCoeffs.at(i) * (*item.second->getPublicKey());
+            i++;
+        }
+        else {
+            break;
+        }
     }
 
     libffPublicKey = std::make_shared< libff::alt_bn128_G2 >( key );

--- a/test/test_bls.cpp
+++ b/test/test_bls.cpp
@@ -219,20 +219,41 @@ BOOST_AUTO_TEST_CASE( libBlsAPI ) {
                     hash_ptr, std::make_shared< BLSSignature >( bad_sign ), num_signed, num_all ),
                 signatures::Bls::IsNotWellFormed );
 
-            std::map< size_t, std::shared_ptr< BLSPublicKeyShare > > pkeys_map;
+            std::map< size_t, std::shared_ptr< BLSPublicKeyShare > > pkeys_map1;
             for ( size_t i = 0; i < num_signed; ++i ) {
                 BLSPublicKeyShare cur_pkey(
                     *Skeys->at( participants.at( i ) - 1 )->getPrivateKey(), num_signed, num_all );
-                pkeys_map[participants.at( i )] = std::make_shared< BLSPublicKeyShare >( cur_pkey );
+                pkeys_map1[participants.at( i )] =
+                    std::make_shared< BLSPublicKeyShare >( cur_pkey );
             }
 
             BLSPublicKey common_pkey1(
                 std::make_shared< std::map< size_t, std::shared_ptr< BLSPublicKeyShare > > >(
-                    pkeys_map ),
+                    pkeys_map1 ),
                 num_signed, num_all );
 
             BOOST_REQUIRE(
                 common_pkey1.VerifySig( hash_ptr, common_sig_ptr, num_signed, num_all ) );
+
+            std::vector< size_t > participants1( num_all );  // use the whole set of participants
+            for ( size_t i = 0; i < num_all; ++i )
+                participants1.at( i ) = i + 1;
+
+            std::map< size_t, std::shared_ptr< BLSPublicKeyShare > > pkeys_map2;
+            for ( size_t i = 0; i < num_all; ++i ) {
+                BLSPublicKeyShare cur_pkey(
+                    *Skeys->at( participants1.at( i ) - 1 )->getPrivateKey(), num_signed, num_all );
+                pkeys_map2[participants1.at( i )] =
+                    std::make_shared< BLSPublicKeyShare >( cur_pkey );
+            }
+
+            BLSPublicKey common_pkey2(
+                std::make_shared< std::map< size_t, std::shared_ptr< BLSPublicKeyShare > > >(
+                    pkeys_map2 ),
+                num_signed, num_all );
+
+            BOOST_REQUIRE(
+                common_pkey2.VerifySig( hash_ptr, common_sig_ptr, num_signed, num_all ) );
         }
     }
     std::cerr << "BLS API TEST END" << std::endl;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs fixes and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
This pull request provides a solution for issue #121.
Line 170 in `BLSPublicKey.cpp` leads to an `out_of_range` exception becasue the vector is accessed with an index that is larger than it's actual size. 

**Why**:
The solution is to stop the iteration over `koefs_pkeys_map`, as soon as the threshold value `_requiredSigners` has been reached.

**How**:
I contacted Oleh on Discord and explained the issues that I've experienced using the specific constructor. 
We were then able to narrow than the root of the error in the implementation of the constructor. 

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

-   [ ] Documentation N/A
-   [x] Tests
-   [x] Ready to be merged
        <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
