### PR TITLE
Move getPublicDecryptionValue into CipheredKey struct

### DIFF
--- a/test/te_sample_sgx.cpp
+++ b/test/te_sample_sgx.cpp
@@ -195,7 +195,7 @@ std::vector< libBLS::TEDecryptionShare > getDecryptionShares(
     for ( size_t i = 0; i < ciphertexts.size(); i++ ) {
         std::shared_ptr< libBLS::Ciphertext > ciphertext = ciphertexts[i];
         libBLS::ThresholdEncryption::validateEncryption( ciphertexts[i]->key );
-        batch.append( ciphertext->getPublicDecryptionValue() );
+        batch.append( ciphertext->key.getDecryptionShareInput() );
     }
 
     TIMER(

--- a/test/unit_tests_te.cpp
+++ b/test/unit_tests_te.cpp
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE( Ciphertext ) {
 
         BOOST_REQUIRE( ciphertext == restoredCiphertext );
 
-        // getPublicDecryptionValue
+        // getDecryptionShareInput
         auto uCopy = u;
         uCopy.to_affine_coordinates();
         auto U = libBLS::ThresholdUtils::G2ToString( uCopy, libBLS::BASE_HEXA );
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE( Ciphertext ) {
         for ( size_t j = 0; j < U.size(); ++j ) {
             concatenated += U[j];
         }
-        BOOST_REQUIRE( ciphertext.getPublicDecryptionValue() == concatenated );
+        BOOST_REQUIRE( ciphertext.key.getDecryptionShareInput() == concatenated );
     }
 }
 
@@ -204,11 +204,11 @@ BOOST_AUTO_TEST_CASE( CiphertextException ) {
     data.resize( libBLS::RANDOM_SECRET_SIZE_BYTES );
     BOOST_REQUIRE_THROW( libBLS::Ciphertext( key, data ), libBLS::ThresholdUtils::IsNotWellFormed );
 
-    // getPublicDecryptionValue - U element from key is not well formed
+    // getDecryptionShareInput - U element from key is not well formed
     libBLS::Ciphertext ciphertext;
     ciphertext.key.U = libff::alt_bn128_G2::zero();
     BOOST_REQUIRE_THROW(
-        ciphertext.getPublicDecryptionValue(), libBLS::ThresholdUtils::IncorrectInput );
+        ciphertext.key.getDecryptionShareInput(), libBLS::ThresholdUtils::IncorrectInput );
 
     // from bytes
     // bytes only allow for key bytes. No data

--- a/threshold_encryption/ThresholdEncryption.h
+++ b/threshold_encryption/ThresholdEncryption.h
@@ -62,7 +62,8 @@ public:
     /**
      * @brief Validates the TE ciphered key
      *
-     * @param _cipheredKey The encrypted AESKey used to encrypt the message held by Ciphertext struct
+     * @param _cipheredKey The encrypted AESKey used to encrypt the message held by Ciphertext
+     * struct
      * @throws Exceptions in case validation fails
      */
     static void validateEncryption( const CipheredKey& _cipheredKey );
@@ -70,7 +71,8 @@ public:
     /**
      * @brief Generates a decryption share for the given ciphered key
      *
-     * @param _cipheredKey The encrypted AESKey used to encrypt the message held by Ciphertext struct
+     * @param _cipheredKey The encrypted AESKey used to encrypt the message held by Ciphertext
+     * struct
      * @param _pkeyShare The private key share
      * @return TEDecryptionShare - The partial decryption share
      */
@@ -80,7 +82,8 @@ public:
     /**
      * @brief Validates a decryption share
      *
-     * @param _cipheredKey The encrypted AESKey used to encrypt the message held by Ciphertext struct
+     * @param _cipheredKey The encrypted AESKey used to encrypt the message held by Ciphertext
+     * struct
      * @param decryption_share The decryption share
      * @throws Exception if the decryption share is not valid
      */
@@ -91,7 +94,8 @@ public:
      * @brief Combines decryption shares to reconstruct the original AES key.
      * It combines all shares to derive the AES key.
      *
-     * @param _cipheredKey The encrypted AESKey used to encrypt the message held by Ciphertext struct
+     * @param _cipheredKey The encrypted AESKey used to encrypt the message held by Ciphertext
+     * struct
      * @param _decryptionSet The decryption set containing the decryption shares
      * @return The deciphered AES key in byte array
      * @throws In case ciphertext is corrupted, or decription set is not ready to be merged

--- a/threshold_encryption/ThresholdEncryption.h
+++ b/threshold_encryption/ThresholdEncryption.h
@@ -47,72 +47,73 @@ public:
     static std::vector< uint8_t > mockupDecrypt( const std::vector< uint8_t >& _encryptedData );
 
     /**
-     * @brief Encrypts a message using a common public key
-     * This function generates a random AES key, and encrypts the message using this key
+     * @brief Encrypts a message using threshold encryption.
+     * This function generates a random AES key, and encrypts the message using this key.
      * This AES key is then encrypted using the common public key from threshold encryption.
      *
-     * @param message The message to be encrypted
-     * @param common_public The common public key used for encryption.
+     * @param _message The message to be encrypted
+     * @param _commonPublic The common public key used for encryption.
      * Public key is validated on constructor. Thus it is assumed to be always valid.
-     * @return Ciphertext The encrypted message
+     * @return Ciphertext - Struct containing TE(AESKey) and AESKey(message)
      */
     static Ciphertext encrypt(
         const std::vector< uint8_t >& _message, const TEPublicKey& _commonPublic );
 
     /**
-     * @brief Validates the encryption of a message (the ciphered AES key)
+     * @brief Validates the TE ciphered key
      *
-     * @param ciphertext The encrypted message
-     * @param pkey_share The private key share
+     * @param _cipheredKey The encrypted AESKey used to encrypt the message held by Ciphertext struct
      * @throws Exceptions in case validation fails
      */
-    static void validateEncryption( const CipheredKey& _ciphertext );
+    static void validateEncryption( const CipheredKey& _cipheredKey );
 
     /**
-     * @brief Generates a decryption share for the given cyphertext (ciphered AES key)
+     * @brief Generates a decryption share for the given ciphered key
      *
-     * @param cyphertext The encrypted message
-     * @param pkey_share The private key share
-     * @return TEDecryptionShare The partial decryption share
+     * @param _cipheredKey The encrypted AESKey used to encrypt the message held by Ciphertext struct
+     * @param _pkeyShare The private key share
+     * @return TEDecryptionShare - The partial decryption share
      */
     static TEDecryptionShare partialDecrypt(
-        const CipheredKey& _cyphertext, const TEPrivateKeyShare& _pkeyShare );
+        const CipheredKey& _cipheredKey, const TEPrivateKeyShare& _pkeyShare );
 
     /**
      * @brief Validates a decryption share
      *
-     * @param cipherText The encrypted message
+     * @param _cipheredKey The encrypted AESKey used to encrypt the message held by Ciphertext struct
      * @param decryption_share The decryption share
      * @throws Exception if the decryption share is not valid
      */
-    static void validateDecryptionShare( const CipheredKey& _cipherText,
+    static void validateDecryptionShare( const CipheredKey& _cipheredKey,
         const TEDecryptionShare& _decryptionShare, const TEPublicKeyShare& _publicKey );
 
     /**
      * @brief Combines decryption shares to reconstruct the original AES key.
      * It combines all shares to derive the AES key.
      *
-     * @param cyphertext The encrypted AES key
-     * @param decryption_set The decryption set containing the decryption shares
+     * @param _cipheredKey The encrypted AESKey used to encrypt the message held by Ciphertext struct
+     * @param _decryptionSet The decryption set containing the decryption shares
      * @return The deciphered AES key in byte array
      * @throws In case ciphertext is corrupted, or decription set is not ready to be merged
      * @note Does not throw error in case there is a corrupted share. But the output
      * will not be the correct deciphered key, since one of the shares is corrupted.
      */
-    static AES256Key combineShares( const CipheredKey& _cypheredKey, TEDecryptSet& _decryptionSet );
+    static AES256Key combineShares( const CipheredKey& _cipheredKey, TEDecryptSet& _decryptionSet );
 
     /**
-     * @brief Validates if the cyphertext corresponds to the given message
+     * @brief Validates if the generated AES key from merging the shares is correct against
+     * the original ciphertext (contains both encrypted AESKey and encrypted data).
      *
-     * @param cyphertext The encrypted message
-     * @param message The original message
+     * @param _ciphertext The encrypted message
+     * @param _aesKey The decrypted AESKey from merging all the shares
+     * @param _publicKey The public key used for threshold encryption
      * @throws IncorrectInput If the cyphertext is too short
      * @throws IsNotWellFormed If the validation fails
      * @throws runtime_exception If the decryption using the AES fails (should only happen if the
      * key is tampered)
      */
     static void validateCombinedDecryption(
-        const Ciphertext& _cyphertext, const AES256Key& _aesKey, const TEPublicKey& _publicKey );
+        const Ciphertext& _ciphertext, const AES256Key& _aesKey, const TEPublicKey& _publicKey );
 
     /**
      * @brief Decrypts a message using the AES key
@@ -130,14 +131,7 @@ public:
      * but avoids deciphering twice - more performant alternative
      */
     static std::vector< uint8_t > validateAndDecrypt(
-        const Ciphertext& _cyphertext, const AES256Key& _aesKey, const TEPublicKey& _publicKey );
-
-
-    static inline std::vector< uint8_t > mergeRandomSecretWithMessage(
-        std::vector< uint8_t > _message, RandSecret _randomSecret ) {
-        _message.insert( _message.end(), _randomSecret.begin(), _randomSecret.end() );
-        return _message;
-    }
+        const Ciphertext& _ciphertext, const AES256Key& _aesKey, const TEPublicKey& _publicKey );
 
 private:
     static std::string bytesToHexaString( const std::vector< uint8_t >& bytes ) {

--- a/threshold_encryption/threshold_encryption.h
+++ b/threshold_encryption/threshold_encryption.h
@@ -134,6 +134,26 @@ public:
         libff::alt_bn128_G1 W = libff::alt_bn128_G1::random_element();
         return CipheredKey( U, V, W );
     }
+
+    /**
+     * Converts U component of the key to string
+     */
+    std::string getDecryptionShareInput() {
+        U.to_affine_coordinates();
+
+        // validate U
+        ThresholdUtils::validateG2( U );
+
+        auto u_splitted = ThresholdUtils::G2ToString( U, BASE_HEXA );
+
+        // convert to string
+        std::string public_decryption_value;
+        for ( size_t j = 0; j < u_splitted.size(); ++j ) {
+            public_decryption_value += u_splitted[j];
+        }
+
+        return public_decryption_value;
+    }
 };
 
 /**
@@ -159,28 +179,6 @@ public:
         : key( _key ), data( std::make_shared< std::vector< uint8_t > >( _data ) ) {
         validate();
     }
-
-    /**
-     * Converts U component of the key to string
-     */
-    std::string getPublicDecryptionValue() {
-        auto U = key.U;
-        U.to_affine_coordinates();
-
-        // validate U
-        ThresholdUtils::validateG2( U );
-
-        auto u_splitted = ThresholdUtils::G2ToString( U, BASE_HEXA );
-
-        // convert to string
-        std::string public_decryption_value;
-        for ( size_t j = 0; j < u_splitted.size(); ++j ) {
-            public_decryption_value += u_splitted[j];
-        }
-
-        return public_decryption_value;
-    }
-
 
     const std::vector< uint8_t >& getData() const {
         if ( !data ) {

--- a/threshold_encryption/threshold_encryption.h
+++ b/threshold_encryption/threshold_encryption.h
@@ -148,8 +148,16 @@ public:
 
         // convert to string
         std::string public_decryption_value;
-        for ( size_t j = 0; j < u_splitted.size(); ++j ) {
-            public_decryption_value += u_splitted[j];
+        size_t total_size = 0;
+
+        for (const auto& part : u_splitted) { 
+            total_size += part.size();
+        }
+
+        public_decryption_value.reserve(total_size);
+
+        for (const auto& part : u_splitted) {
+            public_decryption_value += part;
         }
 
         return public_decryption_value;

--- a/threshold_encryption/threshold_encryption.h
+++ b/threshold_encryption/threshold_encryption.h
@@ -150,13 +150,13 @@ public:
         std::string public_decryption_value;
         size_t total_size = 0;
 
-        for (const auto& part : u_splitted) { 
+        for ( const auto& part : u_splitted ) {
             total_size += part.size();
         }
 
-        public_decryption_value.reserve(total_size);
+        public_decryption_value.reserve( total_size );
 
-        for (const auto& part : u_splitted) {
+        for ( const auto& part : u_splitted ) {
             public_decryption_value += part;
         }
 

--- a/tools/utils.cpp
+++ b/tools/utils.cpp
@@ -76,7 +76,7 @@ std::vector< std::string > ThresholdUtils::G2ToString( libff::alt_bn128_G2 elem,
     return {
         fieldElementToString( elem.X.c0, base ), fieldElementToString( elem.X.c1, base ),
             fieldElementToString( elem.Y.c0, base ), fieldElementToString( elem.Y.c1, base )
-    }
+    };
 }
 
 std::array< uint8_t, G2_SIZE_BYTES > ThresholdUtils::G2ToBytesArray( libff::alt_bn128_G2 elem ) {

--- a/tools/utils.cpp
+++ b/tools/utils.cpp
@@ -74,10 +74,8 @@ void ThresholdUtils::checkSigners( size_t _requiredSigners, size_t _totalSigners
 std::vector< std::string > ThresholdUtils::G2ToString( libff::alt_bn128_G2 elem, int base ) {
     elem.to_affine_coordinates();
     return {
-        fieldElementToString( elem.X.c0, base ),
-        fieldElementToString( elem.X.c1, base ),
-        fieldElementToString( elem.Y.c0, base ),
-        fieldElementToString( elem.Y.c1, base )
+        fieldElementToString( elem.X.c0, base ), fieldElementToString( elem.X.c1, base ),
+            fieldElementToString( elem.Y.c0, base ), fieldElementToString( elem.Y.c1, base )
     }
 }
 

--- a/tools/utils.cpp
+++ b/tools/utils.cpp
@@ -73,10 +73,8 @@ void ThresholdUtils::checkSigners( size_t _requiredSigners, size_t _totalSigners
 
 std::vector< std::string > ThresholdUtils::G2ToString( libff::alt_bn128_G2 elem, int base ) {
     elem.to_affine_coordinates();
-    return {
-        fieldElementToString( elem.X.c0, base ), fieldElementToString( elem.X.c1, base ),
-            fieldElementToString( elem.Y.c0, base ), fieldElementToString( elem.Y.c1, base )
-    };
+    return { fieldElementToString( elem.X.c0, base ), fieldElementToString( elem.X.c1, base ),
+        fieldElementToString( elem.Y.c0, base ), fieldElementToString( elem.Y.c1, base ) };
 }
 
 std::array< uint8_t, G2_SIZE_BYTES > ThresholdUtils::G2ToBytesArray( libff::alt_bn128_G2 elem ) {

--- a/tools/utils.cpp
+++ b/tools/utils.cpp
@@ -72,16 +72,13 @@ void ThresholdUtils::checkSigners( size_t _requiredSigners, size_t _totalSigners
 }
 
 std::vector< std::string > ThresholdUtils::G2ToString( libff::alt_bn128_G2 elem, int base ) {
-    std::vector< std::string > pkey_str_vect;
-
     elem.to_affine_coordinates();
-
-    pkey_str_vect.push_back( fieldElementToString( elem.X.c0, base ) );
-    pkey_str_vect.push_back( fieldElementToString( elem.X.c1, base ) );
-    pkey_str_vect.push_back( fieldElementToString( elem.Y.c0, base ) );
-    pkey_str_vect.push_back( fieldElementToString( elem.Y.c1, base ) );
-
-    return pkey_str_vect;
+    return {
+        fieldElementToString( elem.X.c0, base ),
+        fieldElementToString( elem.X.c1, base ),
+        fieldElementToString( elem.Y.c0, base ),
+        fieldElementToString( elem.Y.c1, base )
+    }
 }
 
 std::array< uint8_t, G2_SIZE_BYTES > ThresholdUtils::G2ToBytesArray( libff::alt_bn128_G2 elem ) {


### PR DESCRIPTION
### Description

- Moved `getPublicDecryptionValue` function from `Ciphertext` to `CipheredKey`
- Updated function name to `getDecryptionShareInput` - describes better the context of its use
- Allows calling it having only the `CIpheredKey`
- Removed unused function `mergeRandomSecretWithMessage`

### Tests
- Updated to call the function on the `CipheredKey` struct

Fixes #250 