### PR TITLE
use thread safe init for curve

### DIFF
--- a/threshold_encryption/threshold_encryption.cpp
+++ b/threshold_encryption/threshold_encryption.cpp
@@ -36,12 +36,12 @@
 namespace libBLS {
 
 TE::TE( const TEBase& base ) : t_( base.getRequiredSigners() ), n_( base.getTotalSigners() ) {
-    libff::init_alt_bn128_params();
+    ThresholdUtils::initCurve();
     libff::inhibit_profiling_info = true;
 }
 
 TE::TE( const size_t t, const size_t n ) : t_( t ), n_( n ) {
-    libff::init_alt_bn128_params();
+    ThresholdUtils::initCurve();
     libff::inhibit_profiling_info = true;
 }
 


### PR DESCRIPTION
use thread safe approach to initialize `libff` library for threshold encryption