### PR TITLE
Update publish workflow to use wasm32-emscripten folder

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,7 +86,7 @@ jobs:
         source ./emsdk_env.sh
         cd ../..
         mkdir -p build_em && cd build_em
-        export LIBRARIES_ROOT=../deps/deps_inst/x86_or_x64/lib
+        export LIBRARIES_ROOT=../deps/deps_inst/wasm32-emscripten/lib
         emcmake cmake -DEMSCRIPTEN=ON -DBUILD_TESTS=OFF -DGMP_LIBRARY="$LIBRARIES_ROOT"/libgmp.a -DCRYPTOPP_LIBRARY="$LIBRARIES_ROOT"/libcrypto.a -DGMPXX_LIBRARY="$LIBRARIES_ROOT"/libgmpxx.a ..
         emmake make -j$(nproc)
         cd ..


### PR DESCRIPTION
## Description

Updates emscripten dependency directory to `wasm32-emscripten` for `publish.yaml` workflow

Fixes #267 