### PR TITLE
improve gmp build

### DIFF
--- a/deps/build.sh
+++ b/deps/build.sh
@@ -742,7 +742,7 @@ then
 			if [ ! -f ""${GMP_NAME}".tar.xz" ];
 			then
 				echo -e "${COLOR_INFO}getting it from gmp website${COLOR_DOTS}...${COLOR_RESET}"
-				eval "$WGET" https://ftp.gnu.org/gnu/gmp/"${GMP_NAME}".tar.xz
+				eval "$WGET" https://gmplib.org/download/gmp/"${GMP_NAME}".tar.xz
 			fi
 			echo -e "${COLOR_INFO}unpacking it${COLOR_DOTS}...${COLOR_RESET}"
 			eval tar -xf "${GMP_NAME}".tar.xz


### PR DESCRIPTION
fixes https://github.com/skalenetwork/libBLS/issues/270
improve gmp build
official `ftp.gnu` often takes a lot of time to connect to. better change it to more reliable source to avoid errors during build 