### PR TITLE
Add AAD (Additional Authenticated Data) for AES_CBC

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,16 @@ jobs:
         run: |
           export SGX_WALLET_TAG=develop-latest
           ./scripts/run_sgx_simulator.sh
-          sleep 60
+          echo "Waiting for SGX wallet to be ready..."
+          for i in {1..60}; do
+            if curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:1029 2>/dev/null | grep -q "405\|200"; then
+              echo "SGX wallet is ready after $((i*2)) seconds"
+              break
+            fi
+            echo "Attempt $i: SGX wallet not ready yet..."
+            sleep 2
+          done
+          docker logs sgx_simulator 2>&1 | tail -20 || true
       - name: Run tests
         run: |
           cp scripts/parameters.json build/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,7 +156,7 @@ jobs:
           make -j$(nproc)
       - name: Run sgxwallet container
         run: |
-          export SGX_WALLET_TAG=e548b375cae741af8fd11db54d6925c27a947af9
+          export SGX_WALLET_TAG=develop-latest
           ./scripts/run_sgx_simulator.sh
           sleep 60
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,7 +156,7 @@ jobs:
           make -j$(nproc)
       - name: Run sgxwallet container
         run: |
-          export SGX_WALLET_TAG=develop-latest
+          export SGX_WALLET_TAG=e548b375cae741af8fd11db54d6925c27a947af9
           ./scripts/run_sgx_simulator.sh
           echo "Waiting for SGX wallet to be ready..."
           for i in {1..60}; do

--- a/scripts/run_sgx_simulator.sh
+++ b/scripts/run_sgx_simulator.sh
@@ -9,4 +9,8 @@ SGX_WALLET_CONTAINER_NAME=sgx_simulator
 
 docker rm -f $SGX_WALLET_CONTAINER_NAME || true
 docker pull $SGX_WALLET_IMAGE_NAME
-docker run -d -p 1026-1031:1026-1031 --name $SGX_WALLET_CONTAINER_NAME $SGX_WALLET_IMAGE_NAME -y -n
+
+# Skip check_firewall.py which uses Tor (blocked in CI) by using custom entrypoint
+docker run -d -p 1026-1031:1026-1031 --name $SGX_WALLET_CONTAINER_NAME \
+  --entrypoint /bin/bash $SGX_WALLET_IMAGE_NAME \
+  -c "source /opt/intel/sgxsdk/environment && cd /usr/src/sdk && ./sgxwallet -y -n"

--- a/scripts/run_sgx_simulator.sh
+++ b/scripts/run_sgx_simulator.sh
@@ -10,7 +10,10 @@ SGX_WALLET_CONTAINER_NAME=sgx_simulator
 docker rm -f $SGX_WALLET_CONTAINER_NAME || true
 docker pull $SGX_WALLET_IMAGE_NAME
 
-# Skip check_firewall.py which uses Tor (blocked in CI) by using custom entrypoint
+# The default entrypoint (start.sh) runs check_firewall.py before starting sgxwallet.
+# check_firewall.py uses Tor to verify that sgxwallet ports aren't exposed to the internet.
+# However, Tor connectivity is blocked in GitHub Actions, causing the script to hang indefinitely.
+# Workaround: Use a custom entrypoint that skips check_firewall.py and starts sgxwallet directly.
 docker run -d -p 1026-1031:1026-1031 --name $SGX_WALLET_CONTAINER_NAME \
   --entrypoint /bin/bash $SGX_WALLET_IMAGE_NAME \
   -c "source /opt/intel/sgxsdk/environment && cd /usr/src/sdk && ./sgxwallet -y -n"

--- a/test/test.js
+++ b/test/test.js
@@ -2,14 +2,15 @@ const ModuleFactory = require("./encrypt.js");
 
 const BLS_PUBLIC_KEY = process.argv[2];
 const TX_DATA = process.argv[3];
+const ADDITIONAL_AUTHENTICATED_DATA = process.argv[4] || "";
 
 ModuleFactory().then((Module) => {
     // Use the Module object after it is initialized
     const result = Module.ccall(
         'encryptMessage', // Name of the exported C++ function
         'string',         // Return type
-        ['string', 'string'], // Argument types
-        [TX_DATA, BLS_PUBLIC_KEY] // Arguments
+        ['string', 'string', 'string'], // Argument types
+        [TX_DATA, BLS_PUBLIC_KEY, ADDITIONAL_AUTHENTICATED_DATA] // Arguments
     );
     console.log(result);
 }).catch((error) => {

--- a/test/test2Keys.js
+++ b/test/test2Keys.js
@@ -3,14 +3,15 @@ const ModuleFactory = require("./encrypt.js");
 const FIRST_BLS_PUBLIC_KEY = process.argv[2];
 const SECOND_BLS_PUBLIC_KEY = process.argv[3];
 const TX_DATA = process.argv[4];
+const ADDITIONAL_AUTHENTICATED_DATA = process.argv[5] || "";
 
 ModuleFactory().then((Module) => {
     // Use the Module object after it is initialized
     const result = Module.ccall(
         'encryptMessageDualKey', // Name of the exported C++ function
         'string',         // Return type
-        ['string', 'string', 'string'], // Argument types
-        [TX_DATA, FIRST_BLS_PUBLIC_KEY, SECOND_BLS_PUBLIC_KEY] // Arguments
+        ['string', 'string', 'string', 'string'], // Argument types
+        [TX_DATA, FIRST_BLS_PUBLIC_KEY, SECOND_BLS_PUBLIC_KEY, ADDITIONAL_AUTHENTICATED_DATA] // Arguments
     );
     console.log(result);
 }).catch((error) => {

--- a/test/test_TE_wrappers.cpp
+++ b/test/test_TE_wrappers.cpp
@@ -90,7 +90,8 @@ BOOST_AUTO_TEST_CASE( TEEncryptDecryptWithAAD ) {
     std::vector< uint8_t > aad = { 0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE };
 
     // Encrypt with AAD
-    libBLS::Ciphertext cypher = libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic, aad );
+    libBLS::Ciphertext cypher =
+        libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic, aad );
 
     std::vector< libBLS::TEPublicKeyShare > public_key_shares;
     for ( size_t i = 0; i < numAll; i++ ) {
@@ -134,7 +135,8 @@ BOOST_AUTO_TEST_CASE( TEEncryptDecryptWithWrongAAD ) {
     std::vector< uint8_t > wrong_aad = { 0x01, 0x02, 0x03, 0x04 };
 
     // Encrypt with AAD
-    libBLS::Ciphertext cypher = libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic, aad );
+    libBLS::Ciphertext cypher =
+        libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic, aad );
 
     std::vector< libBLS::TEPublicKeyShare > public_key_shares;
     for ( size_t i = 0; i < numAll; i++ ) {

--- a/test/test_TE_wrappers.cpp
+++ b/test/test_TE_wrappers.cpp
@@ -77,6 +77,93 @@ BOOST_AUTO_TEST_CASE( TEMockupEncryption ) {
     BOOST_REQUIRE( message == decryptedMsg );
 }
 
+BOOST_AUTO_TEST_CASE( TEEncryptDecryptWithAAD ) {
+    // Test the full ThresholdEncryption::encrypt/decrypt flow with AAD
+    size_t numAll = 4;
+    size_t numSigned = 3;
+
+    keys keys = generateKeys( numSigned, numAll );
+
+    std::vector< uint8_t > message = randomByteVec( 100 );
+
+    // AAD that binds the ciphertext to a specific context (e.g., contract address)
+    std::vector< uint8_t > aad = { 0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE };
+
+    // Encrypt with AAD
+    libBLS::Ciphertext cypher = libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic, aad );
+
+    std::vector< libBLS::TEPublicKeyShare > public_key_shares;
+    for ( size_t i = 0; i < numAll; i++ ) {
+        public_key_shares.emplace_back( libBLS::TEPublicKeyShare( keys.secretKeys[i] ) );
+    }
+
+    for ( const auto& cipheredKey : cypher.getKeys() ) {
+        libBLS::ThresholdEncryption::validateEncryption( cipheredKey );
+
+        libBLS::TEDecryptSet decrSet( numSigned, numAll );
+        for ( size_t i = 0; i < numSigned; i++ ) {
+            libBLS::TEDecryptionShare decr_share =
+                libBLS::ThresholdEncryption::partialDecrypt( cipheredKey, keys.secretKeys[i] );
+            libBLS::ThresholdEncryption::validateDecryptionShare(
+                cipheredKey, decr_share, public_key_shares[i] );
+            decrSet.addDecryptShare( decr_share );
+        }
+
+        libBLS::AES256Key key_decrypted =
+            libBLS::ThresholdEncryption::combineShares( cipheredKey, decrSet );
+
+        // Decrypt WITH the same AAD - should succeed
+        std::vector< uint8_t > decipheredMsg =
+            libBLS::ThresholdEncryption::decrypt( cypher, key_decrypted, aad );
+        BOOST_REQUIRE( decipheredMsg == message );
+    }
+}
+
+BOOST_AUTO_TEST_CASE( TEEncryptDecryptWithWrongAAD ) {
+    // Test that decryption fails when AAD doesn't match
+    size_t numAll = 4;
+    size_t numSigned = 3;
+
+    keys keys = generateKeys( numSigned, numAll );
+
+    std::vector< uint8_t > message = randomByteVec( 100 );
+
+    // AAD used for encryption
+    std::vector< uint8_t > aad = { 0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE };
+    // Wrong AAD for decryption
+    std::vector< uint8_t > wrong_aad = { 0x01, 0x02, 0x03, 0x04 };
+
+    // Encrypt with AAD
+    libBLS::Ciphertext cypher = libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic, aad );
+
+    std::vector< libBLS::TEPublicKeyShare > public_key_shares;
+    for ( size_t i = 0; i < numAll; i++ ) {
+        public_key_shares.emplace_back( libBLS::TEPublicKeyShare( keys.secretKeys[i] ) );
+    }
+
+    for ( const auto& cipheredKey : cypher.getKeys() ) {
+        libBLS::TEDecryptSet decrSet( numSigned, numAll );
+        for ( size_t i = 0; i < numSigned; i++ ) {
+            libBLS::TEDecryptionShare decr_share =
+                libBLS::ThresholdEncryption::partialDecrypt( cipheredKey, keys.secretKeys[i] );
+            decrSet.addDecryptShare( decr_share );
+        }
+
+        libBLS::AES256Key key_decrypted =
+            libBLS::ThresholdEncryption::combineShares( cipheredKey, decrSet );
+
+        // Decrypt with wrong AAD - should fail
+        BOOST_REQUIRE_THROW(
+            libBLS::ThresholdEncryption::decrypt( cypher, key_decrypted, wrong_aad ),
+            std::runtime_error );
+
+        // Decrypt without AAD - should also fail
+        BOOST_REQUIRE_THROW(
+            libBLS::ThresholdEncryption::decrypt( cypher, key_decrypted, std::nullopt ),
+            std::runtime_error );
+    }
+}
+
 BOOST_AUTO_TEST_CASE( TEProcessWithWrappers ) {
     for ( size_t i = 0; i < 10; i++ ) {
         size_t numAll = rand_gen() % 16 + 1;

--- a/test/test_encrypt_message.cpp
+++ b/test/test_encrypt_message.cpp
@@ -63,10 +63,12 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
         std::string str = libBLS::ThresholdUtils::bytesToHexString( data );
         const char* dataStr = str.c_str();
 
-        std::string additionalAuthenticatedDataStr = "additionalAuthenticatedData";
+        std::vector< uint8_t > additionalAuthenticatedData = { 'a', 'd', 'd', 'i', 't', 'i', 'o',
+            'n', 'a', 'l', 'A', 'u', 't', 'h', 'e', 'n', 't', 'i', 'c', 'a', 't', 'e', 'd', 'D', 'a',
+            't', 'a' };
+        std::string additionalAuthenticatedDataStr =
+            libBLS::ThresholdUtils::bytesToHexString( additionalAuthenticatedData );
         const char* additionalAuthenticatedDataStrC = additionalAuthenticatedDataStr.c_str();
-        std::vector< uint8_t > additionalAuthenticatedData =
-            libBLS::ThresholdUtils::hexCStringToBytes( additionalAuthenticatedDataStrC );
 
         // call encrypt message
         const char* cipheredMessage =
@@ -99,8 +101,8 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
 
             libBLS::AES256Key key_deciphered =
                 libBLS::ThresholdEncryption::combineShares( cipheredKey, decr_set );
-            libBLS::ThresholdEncryption::validateCombinedDecryption(
-                cipheredMessageObj, key_deciphered, keys.commonPublic.getPublicKeyRaw() );
+            libBLS::ThresholdEncryption::validateCombinedDecryption( cipheredMessageObj,
+                key_deciphered, keys.commonPublic.getPublicKeyRaw(), additionalAuthenticatedData );
             std::vector< uint8_t > decipheredMsg = libBLS::ThresholdEncryption::decrypt(
                 cipheredMessageObj, key_deciphered, additionalAuthenticatedData );
 
@@ -132,10 +134,12 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
             publicKeysStr[j] = pKeyStr;
         }
 
-        std::string additionalAuthenticatedDataStr = "additionalAuthenticatedData";
+        std::vector< uint8_t > additionalAuthenticatedData = { 'a', 'd', 'd', 'i', 't', 'i', 'o',
+            'n', 'a', 'l', 'A', 'u', 't', 'h', 'e', 'n', 't', 'i', 'c', 'a', 't', 'e', 'd', 'D', 'a',
+            't', 'a' };
+        std::string additionalAuthenticatedDataStr =
+            libBLS::ThresholdUtils::bytesToHexString( additionalAuthenticatedData );
         const char* additionalAuthenticatedDataStrC = additionalAuthenticatedDataStr.c_str();
-        std::vector< uint8_t > additionalAuthenticatedData =
-            libBLS::ThresholdUtils::hexCStringToBytes( additionalAuthenticatedDataStrC );
 
         // call encrypt message
         const char* cipheredMessage = encryptMessageDualKey( dataStr, publicKeysStr[0].c_str(),
@@ -174,20 +178,22 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
                 libBLS::ThresholdEncryption::combineShares( cipheredKeys[k], decr_set );
             libBLS::Ciphertext tempCipheredMessage(
                 cipheredMessageObj.getKeys()[k], cipheredMessageObj.getData() );
-            libBLS::ThresholdEncryption::validateCombinedDecryption(
-                tempCipheredMessage, key_deciphered, keys[k].commonPublic.getPublicKeyRaw() );
+            libBLS::ThresholdEncryption::validateCombinedDecryption( tempCipheredMessage,
+                key_deciphered, keys[k].commonPublic.getPublicKeyRaw(), additionalAuthenticatedData );
             std::vector< uint8_t > decipheredMsg = libBLS::ThresholdEncryption::decrypt(
                 tempCipheredMessage, key_deciphered, additionalAuthenticatedData );
 
             BOOST_REQUIRE( decipheredMsg == data );
 
             auto ciphertextCopy = cipheredMessageObj;
-            BOOST_REQUIRE_THROW( libBLS::ThresholdEncryption::validateAndDecrypt(
-                                     ciphertextCopy, key_deciphered, keys[k].commonPublic ),
+            BOOST_REQUIRE_THROW(
+                libBLS::ThresholdEncryption::validateAndDecrypt(
+                    ciphertextCopy, key_deciphered, keys[k].commonPublic, additionalAuthenticatedData ),
                 libBLS::ThresholdUtils::IncorrectInput );
             ciphertextCopy.keepKey( k );
-            BOOST_REQUIRE( libBLS::ThresholdEncryption::validateAndDecrypt(
-                               ciphertextCopy, key_deciphered, keys[k].commonPublic ) == data );
+            BOOST_REQUIRE( libBLS::ThresholdEncryption::validateAndDecrypt( ciphertextCopy,
+                               key_deciphered, keys[k].commonPublic, additionalAuthenticatedData ) ==
+                           data );
         }
     }
 }

--- a/test/test_encrypt_message.cpp
+++ b/test/test_encrypt_message.cpp
@@ -69,13 +69,15 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
             libBLS::ThresholdUtils::hexCStringToBytes( additionalAuthenticatedDataStrC );
 
         // call encrypt message
-        const char* cipheredMessage = encryptMessage( dataStr, pKeyStr.c_str(), additionalAuthenticatedDataStrC );
+        const char* cipheredMessage =
+            encryptMessage( dataStr, pKeyStr.c_str(), additionalAuthenticatedDataStrC );
         std::vector< uint8_t > cipheredMessageBytesActual =
             libBLS::ThresholdUtils::hexCStringToBytes( cipheredMessage );
 
         // encrypt message using libBLS
         libBLS::TEPublicKey publicKey( pKeyStr, libBLS::Base::HEXA );
-        libBLS::Ciphertext ciphertext = libBLS::ThresholdEncryption::encrypt( data, publicKey, additionalAuthenticatedData );
+        libBLS::Ciphertext ciphertext =
+            libBLS::ThresholdEncryption::encrypt( data, publicKey, additionalAuthenticatedData );
         std::vector< uint8_t > cipheredMessageBytesTarget = ciphertext.toBytes();
 
         // cannot compare their contents since each has a different random secret, which results
@@ -99,8 +101,8 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
                 libBLS::ThresholdEncryption::combineShares( cipheredKey, decr_set );
             libBLS::ThresholdEncryption::validateCombinedDecryption(
                 cipheredMessageObj, key_deciphered, keys.commonPublic.getPublicKeyRaw() );
-            std::vector< uint8_t > decipheredMsg =
-                libBLS::ThresholdEncryption::decrypt( cipheredMessageObj, key_deciphered, additionalAuthenticatedData );
+            std::vector< uint8_t > decipheredMsg = libBLS::ThresholdEncryption::decrypt(
+                cipheredMessageObj, key_deciphered, additionalAuthenticatedData );
 
             BOOST_REQUIRE( decipheredMsg == data );
         }
@@ -136,8 +138,8 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
             libBLS::ThresholdUtils::hexCStringToBytes( additionalAuthenticatedDataStrC );
 
         // call encrypt message
-        const char* cipheredMessage =
-            encryptMessageDualKey( dataStr, publicKeysStr[0].c_str(), publicKeysStr[1].c_str(), additionalAuthenticatedDataStrC );
+        const char* cipheredMessage = encryptMessageDualKey( dataStr, publicKeysStr[0].c_str(),
+            publicKeysStr[1].c_str(), additionalAuthenticatedDataStrC );
         std::vector< uint8_t > cipheredMessageBytesActual =
             libBLS::ThresholdUtils::hexCStringToBytes( cipheredMessage );
 
@@ -146,8 +148,8 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
         for ( const auto& publicKey : publicKeysStr ) {
             commonPublicKeys.push_back( libBLS::TEPublicKey( publicKey, libBLS::Base::HEXA ) );
         }
-        libBLS::Ciphertext ciphertext =
-            libBLS::ThresholdEncryption::encrypt( data, commonPublicKeys, additionalAuthenticatedData );
+        libBLS::Ciphertext ciphertext = libBLS::ThresholdEncryption::encrypt(
+            data, commonPublicKeys, additionalAuthenticatedData );
         std::vector< uint8_t > cipheredMessageBytesTarget = ciphertext.toBytes();
 
         // cannot compare their contents since each has a different random secret, which results
@@ -174,8 +176,8 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
                 cipheredMessageObj.getKeys()[k], cipheredMessageObj.getData() );
             libBLS::ThresholdEncryption::validateCombinedDecryption(
                 tempCipheredMessage, key_deciphered, keys[k].commonPublic.getPublicKeyRaw() );
-            std::vector< uint8_t > decipheredMsg =
-                libBLS::ThresholdEncryption::decrypt( tempCipheredMessage, key_deciphered, additionalAuthenticatedData );
+            std::vector< uint8_t > decipheredMsg = libBLS::ThresholdEncryption::decrypt(
+                tempCipheredMessage, key_deciphered, additionalAuthenticatedData );
 
             BOOST_REQUIRE( decipheredMsg == data );
 

--- a/test/test_encrypt_message.cpp
+++ b/test/test_encrypt_message.cpp
@@ -64,8 +64,8 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
         const char* dataStr = str.c_str();
 
         std::vector< uint8_t > additionalAuthenticatedData = { 'a', 'd', 'd', 'i', 't', 'i', 'o',
-            'n', 'a', 'l', 'A', 'u', 't', 'h', 'e', 'n', 't', 'i', 'c', 'a', 't', 'e', 'd', 'D', 'a',
-            't', 'a' };
+            'n', 'a', 'l', 'A', 'u', 't', 'h', 'e', 'n', 't', 'i', 'c', 'a', 't', 'e', 'd', 'D',
+            'a', 't', 'a' };
         std::string additionalAuthenticatedDataStr =
             libBLS::ThresholdUtils::bytesToHexString( additionalAuthenticatedData );
         const char* additionalAuthenticatedDataStrC = additionalAuthenticatedDataStr.c_str();
@@ -135,8 +135,8 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
         }
 
         std::vector< uint8_t > additionalAuthenticatedData = { 'a', 'd', 'd', 'i', 't', 'i', 'o',
-            'n', 'a', 'l', 'A', 'u', 't', 'h', 'e', 'n', 't', 'i', 'c', 'a', 't', 'e', 'd', 'D', 'a',
-            't', 'a' };
+            'n', 'a', 'l', 'A', 'u', 't', 'h', 'e', 'n', 't', 'i', 'c', 'a', 't', 'e', 'd', 'D',
+            'a', 't', 'a' };
         std::string additionalAuthenticatedDataStr =
             libBLS::ThresholdUtils::bytesToHexString( additionalAuthenticatedData );
         const char* additionalAuthenticatedDataStrC = additionalAuthenticatedDataStr.c_str();
@@ -179,7 +179,8 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
             libBLS::Ciphertext tempCipheredMessage(
                 cipheredMessageObj.getKeys()[k], cipheredMessageObj.getData() );
             libBLS::ThresholdEncryption::validateCombinedDecryption( tempCipheredMessage,
-                key_deciphered, keys[k].commonPublic.getPublicKeyRaw(), additionalAuthenticatedData );
+                key_deciphered, keys[k].commonPublic.getPublicKeyRaw(),
+                additionalAuthenticatedData );
             std::vector< uint8_t > decipheredMsg = libBLS::ThresholdEncryption::decrypt(
                 tempCipheredMessage, key_deciphered, additionalAuthenticatedData );
 
@@ -187,13 +188,13 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
 
             auto ciphertextCopy = cipheredMessageObj;
             BOOST_REQUIRE_THROW(
-                libBLS::ThresholdEncryption::validateAndDecrypt(
-                    ciphertextCopy, key_deciphered, keys[k].commonPublic, additionalAuthenticatedData ),
+                libBLS::ThresholdEncryption::validateAndDecrypt( ciphertextCopy, key_deciphered,
+                    keys[k].commonPublic, additionalAuthenticatedData ),
                 libBLS::ThresholdUtils::IncorrectInput );
             ciphertextCopy.keepKey( k );
-            BOOST_REQUIRE( libBLS::ThresholdEncryption::validateAndDecrypt( ciphertextCopy,
-                               key_deciphered, keys[k].commonPublic, additionalAuthenticatedData ) ==
-                           data );
+            BOOST_REQUIRE(
+                libBLS::ThresholdEncryption::validateAndDecrypt( ciphertextCopy, key_deciphered,
+                    keys[k].commonPublic, additionalAuthenticatedData ) == data );
         }
     }
 }

--- a/test/test_encrypt_message.cpp
+++ b/test/test_encrypt_message.cpp
@@ -63,14 +63,19 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
         std::string str = libBLS::ThresholdUtils::bytesToHexString( data );
         const char* dataStr = str.c_str();
 
+        std::string additionalAuthenticatedDataStr = "additionalAuthenticatedData";
+        const char* additionalAuthenticatedDataStrC = additionalAuthenticatedDataStr.c_str();
+        std::vector< uint8_t > additionalAuthenticatedData =
+            libBLS::ThresholdUtils::hexCStringToBytes( additionalAuthenticatedDataStrC );
+
         // call encrypt message
-        const char* cipheredMessage = encryptMessage( dataStr, pKeyStr.c_str() );
+        const char* cipheredMessage = encryptMessage( dataStr, pKeyStr.c_str(), additionalAuthenticatedDataStrC );
         std::vector< uint8_t > cipheredMessageBytesActual =
             libBLS::ThresholdUtils::hexCStringToBytes( cipheredMessage );
 
         // encrypt message using libBLS
         libBLS::TEPublicKey publicKey( pKeyStr, libBLS::Base::HEXA );
-        libBLS::Ciphertext ciphertext = libBLS::ThresholdEncryption::encrypt( data, publicKey );
+        libBLS::Ciphertext ciphertext = libBLS::ThresholdEncryption::encrypt( data, publicKey, additionalAuthenticatedData );
         std::vector< uint8_t > cipheredMessageBytesTarget = ciphertext.toBytes();
 
         // cannot compare their contents since each has a different random secret, which results
@@ -95,7 +100,7 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
             libBLS::ThresholdEncryption::validateCombinedDecryption(
                 cipheredMessageObj, key_deciphered, keys.commonPublic.getPublicKeyRaw() );
             std::vector< uint8_t > decipheredMsg =
-                libBLS::ThresholdEncryption::decrypt( cipheredMessageObj, key_deciphered );
+                libBLS::ThresholdEncryption::decrypt( cipheredMessageObj, key_deciphered, additionalAuthenticatedData );
 
             BOOST_REQUIRE( decipheredMsg == data );
         }
@@ -125,9 +130,14 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
             publicKeysStr[j] = pKeyStr;
         }
 
+        std::string additionalAuthenticatedDataStr = "additionalAuthenticatedData";
+        const char* additionalAuthenticatedDataStrC = additionalAuthenticatedDataStr.c_str();
+        std::vector< uint8_t > additionalAuthenticatedData =
+            libBLS::ThresholdUtils::hexCStringToBytes( additionalAuthenticatedDataStrC );
+
         // call encrypt message
         const char* cipheredMessage =
-            encryptMessageDualKey( dataStr, publicKeysStr[0].c_str(), publicKeysStr[1].c_str() );
+            encryptMessageDualKey( dataStr, publicKeysStr[0].c_str(), publicKeysStr[1].c_str(), additionalAuthenticatedDataStrC );
         std::vector< uint8_t > cipheredMessageBytesActual =
             libBLS::ThresholdUtils::hexCStringToBytes( cipheredMessage );
 
@@ -137,7 +147,7 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
             commonPublicKeys.push_back( libBLS::TEPublicKey( publicKey, libBLS::Base::HEXA ) );
         }
         libBLS::Ciphertext ciphertext =
-            libBLS::ThresholdEncryption::encrypt( data, commonPublicKeys );
+            libBLS::ThresholdEncryption::encrypt( data, commonPublicKeys, additionalAuthenticatedData );
         std::vector< uint8_t > cipheredMessageBytesTarget = ciphertext.toBytes();
 
         // cannot compare their contents since each has a different random secret, which results
@@ -165,7 +175,7 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
             libBLS::ThresholdEncryption::validateCombinedDecryption(
                 tempCipheredMessage, key_deciphered, keys[k].commonPublic.getPublicKeyRaw() );
             std::vector< uint8_t > decipheredMsg =
-                libBLS::ThresholdEncryption::decrypt( tempCipheredMessage, key_deciphered );
+                libBLS::ThresholdEncryption::decrypt( tempCipheredMessage, key_deciphered, additionalAuthenticatedData );
 
             BOOST_REQUIRE( decipheredMsg == data );
 

--- a/test/unit_tests_te.cpp
+++ b/test/unit_tests_te.cpp
@@ -502,10 +502,12 @@ BOOST_AUTO_TEST_CASE( EncryptionWithAES_WrongAAD ) {
 
         // Decrypt with wrong AAD - should fail
         libBLS::AesGcmCipher aesGcmCipher{ decrypted_aes_key };
-        BOOST_REQUIRE_THROW( aesGcmCipher.decrypt( encrypted_message, wrong_aad ), std::runtime_error );
+        BOOST_REQUIRE_THROW(
+            aesGcmCipher.decrypt( encrypted_message, wrong_aad ), std::runtime_error );
 
         // Decrypt without AAD - should also fail
-        BOOST_REQUIRE_THROW( aesGcmCipher.decrypt( encrypted_message, std::nullopt ), std::runtime_error );
+        BOOST_REQUIRE_THROW(
+            aesGcmCipher.decrypt( encrypted_message, std::nullopt ), std::runtime_error );
     }
 }
 

--- a/test/unit_tests_te.cpp
+++ b/test/unit_tests_te.cpp
@@ -43,103 +43,103 @@ BOOST_AUTO_TEST_SUITE( TestAES )
 
 BOOST_AUTO_TEST_CASE( SimpleAES ) {
     libBLS::ThresholdUtils::initRAND();
-    unsigned char key_bytes[32];
-    RAND_bytes( key_bytes, sizeof( key_bytes ) );
-    libBLS::AES256Key random_aes_key;
-    std::copy( key_bytes, key_bytes + libBLS::AES_256_KEY_SIZE_BYTES, random_aes_key.begin() );
+    unsigned char keyBytes[32];
+    RAND_bytes( keyBytes, sizeof( keyBytes ) );
+    libBLS::AES256Key randomAesKey;
+    std::copy( keyBytes, keyBytes + libBLS::AES_256_KEY_SIZE_BYTES, randomAesKey.begin() );
 
     const std::string message = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-    std::vector< uint8_t > message_bytes( message.begin(), message.end() );
+    std::vector< uint8_t > messageBytes( message.begin(), message.end() );
 
-    libBLS::AesGcmCipher cipher{ random_aes_key };
-    auto ciphertext = cipher.encrypt( message_bytes );
-    auto decrypted_text = cipher.decrypt( ciphertext );
+    libBLS::AesGcmCipher cipher{ randomAesKey };
+    auto ciphertext = cipher.encrypt( messageBytes );
+    auto decryptedText = cipher.decrypt( ciphertext );
 
-    BOOST_REQUIRE( decrypted_text == message_bytes );
+    BOOST_REQUIRE( decryptedText == messageBytes );
 }
 
 BOOST_AUTO_TEST_CASE( wrongCiphertext ) {
     libBLS::ThresholdUtils::initRAND();
-    libBLS::AES256Key random_aes_key;
-    RAND_bytes( random_aes_key.data(), random_aes_key.size() );
+    libBLS::AES256Key randomAesKey;
+    RAND_bytes( randomAesKey.data(), randomAesKey.size() );
 
     const std::string message = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-    std::vector< uint8_t > message_bytes( message.begin(), message.end() );
+    std::vector< uint8_t > messageBytes( message.begin(), message.end() );
 
-    const std::string bad_message =
+    const std::string badMessage =
         "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
-    std::vector< uint8_t > bad_message_bytes( bad_message.begin(), bad_message.end() );
+    std::vector< uint8_t > badMessageBytes( badMessage.begin(), badMessage.end() );
 
-    libBLS::AesGcmCipher cipher{ random_aes_key };
-    auto bad_ciphertext = cipher.encrypt( bad_message_bytes );
+    libBLS::AesGcmCipher cipher{ randomAesKey };
+    auto bad_ciphertext = cipher.encrypt( badMessageBytes );
 
-    auto decrypted_text = cipher.decrypt( bad_ciphertext );
+    auto decryptedText = cipher.decrypt( bad_ciphertext );
 
-    BOOST_REQUIRE( decrypted_text != message_bytes );
-    BOOST_REQUIRE( decrypted_text == bad_message_bytes );
+    BOOST_REQUIRE( decryptedText != messageBytes );
+    BOOST_REQUIRE( decryptedText == badMessageBytes );
 }
 
 BOOST_AUTO_TEST_CASE( wrongKey ) {
     libBLS::ThresholdUtils::initRAND();
-    unsigned char key_bytes[32];
-    RAND_bytes( key_bytes, sizeof( key_bytes ) );
-    libBLS::AES256Key random_aes_key;
-    std::copy( key_bytes, key_bytes + libBLS::AES_256_KEY_SIZE_BYTES, random_aes_key.begin() );
+    unsigned char keyBytes[32];
+    RAND_bytes( keyBytes, sizeof( keyBytes ) );
+    libBLS::AES256Key randomAesKey;
+    std::copy( keyBytes, keyBytes + libBLS::AES_256_KEY_SIZE_BYTES, randomAesKey.begin() );
 
     const std::string message = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-    std::vector< uint8_t > message_bytes( message.begin(), message.end() );
+    std::vector< uint8_t > messageBytes( message.begin(), message.end() );
 
-    libBLS::AesGcmCipher cipher{ random_aes_key };
-    auto ciphertext = cipher.encrypt( message_bytes );
+    libBLS::AesGcmCipher cipher{ randomAesKey };
+    auto ciphertext = cipher.encrypt( messageBytes );
 
-    unsigned char bad_key_bytes[32];
-    RAND_bytes( bad_key_bytes, sizeof( bad_key_bytes ) );
-    libBLS::AES256Key random_bad_aes_key;
+    unsigned char bad_keyBytes[32];
+    RAND_bytes( bad_keyBytes, sizeof( bad_keyBytes ) );
+    libBLS::AES256Key randomBadAesKey;
     std::copy(
-        bad_key_bytes, bad_key_bytes + libBLS::AES_256_KEY_SIZE_BYTES, random_bad_aes_key.begin() );
+        bad_keyBytes, bad_keyBytes + libBLS::AES_256_KEY_SIZE_BYTES, randomBadAesKey.begin() );
 
-    libBLS::AesGcmCipher bad_cipher{ random_bad_aes_key };
+    libBLS::AesGcmCipher bad_cipher{ randomBadAesKey };
     BOOST_REQUIRE_THROW( bad_cipher.decrypt( ciphertext ), std::runtime_error );
 }
 
 BOOST_AUTO_TEST_CASE( AESWithAAD ) {
     libBLS::ThresholdUtils::initRAND();
-    libBLS::AES256Key random_aes_key;
-    RAND_bytes( random_aes_key.data(), random_aes_key.size() );
+    libBLS::AES256Key randomAesKey;
+    RAND_bytes( randomAesKey.data(), randomAesKey.size() );
 
     const std::string message = "Hello, this is a test message for AAD encryption!";
-    std::vector< uint8_t > message_bytes( message.begin(), message.end() );
+    std::vector< uint8_t > messageBytes( message.begin(), message.end() );
 
     // Create AAD (additional authenticated data)
     std::vector< uint8_t > aad = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
 
-    libBLS::AesGcmCipher cipher{ random_aes_key };
+    libBLS::AesGcmCipher cipher{ randomAesKey };
 
     // Encrypt with AAD
-    auto ciphertext = cipher.encrypt( message_bytes, aad );
+    auto ciphertext = cipher.encrypt( messageBytes, aad );
 
     // Decrypt with same AAD - should succeed
-    auto decrypted_text = cipher.decrypt( ciphertext, aad );
-    BOOST_REQUIRE( decrypted_text == message_bytes );
+    auto decryptedText = cipher.decrypt( ciphertext, aad );
+    BOOST_REQUIRE( decryptedText == messageBytes );
 }
 
 BOOST_AUTO_TEST_CASE( AESWithWrongAAD ) {
     libBLS::ThresholdUtils::initRAND();
-    libBLS::AES256Key random_aes_key;
-    RAND_bytes( random_aes_key.data(), random_aes_key.size() );
+    libBLS::AES256Key randomAesKey;
+    RAND_bytes( randomAesKey.data(), randomAesKey.size() );
 
     const std::string message = "Hello, this is a test message for AAD encryption!";
-    std::vector< uint8_t > message_bytes( message.begin(), message.end() );
+    std::vector< uint8_t > messageBytes( message.begin(), message.end() );
 
     // Create AAD
     std::vector< uint8_t > aad = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
     // Different AAD
     std::vector< uint8_t > wrong_aad = { 0xFF, 0xFE, 0xFD, 0xFC };
 
-    libBLS::AesGcmCipher cipher{ random_aes_key };
+    libBLS::AesGcmCipher cipher{ randomAesKey };
 
     // Encrypt with AAD
-    auto ciphertext = cipher.encrypt( message_bytes, aad );
+    auto ciphertext = cipher.encrypt( messageBytes, aad );
 
     // Decrypt with different AAD - should fail (authentication error)
     BOOST_REQUIRE_THROW( cipher.decrypt( ciphertext, wrong_aad ), std::runtime_error );
@@ -147,19 +147,19 @@ BOOST_AUTO_TEST_CASE( AESWithWrongAAD ) {
 
 BOOST_AUTO_TEST_CASE( AESWithMissingAAD ) {
     libBLS::ThresholdUtils::initRAND();
-    libBLS::AES256Key random_aes_key;
-    RAND_bytes( random_aes_key.data(), random_aes_key.size() );
+    libBLS::AES256Key randomAesKey;
+    RAND_bytes( randomAesKey.data(), randomAesKey.size() );
 
     const std::string message = "Hello, this is a test message for AAD encryption!";
-    std::vector< uint8_t > message_bytes( message.begin(), message.end() );
+    std::vector< uint8_t > messageBytes( message.begin(), message.end() );
 
     // Create AAD
     std::vector< uint8_t > aad = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
 
-    libBLS::AesGcmCipher cipher{ random_aes_key };
+    libBLS::AesGcmCipher cipher{ randomAesKey };
 
     // Encrypt with AAD
-    auto ciphertext = cipher.encrypt( message_bytes, aad );
+    auto ciphertext = cipher.encrypt( messageBytes, aad );
 
     // Decrypt without AAD (nullopt) - should fail (authentication error)
     BOOST_REQUIRE_THROW( cipher.decrypt( ciphertext, std::nullopt ), std::runtime_error );
@@ -167,50 +167,50 @@ BOOST_AUTO_TEST_CASE( AESWithMissingAAD ) {
 
 BOOST_AUTO_TEST_CASE( AESWithoutAAD_BackwardCompatibility ) {
     libBLS::ThresholdUtils::initRAND();
-    libBLS::AES256Key random_aes_key;
-    RAND_bytes( random_aes_key.data(), random_aes_key.size() );
+    libBLS::AES256Key randomAesKey;
+    RAND_bytes( randomAesKey.data(), randomAesKey.size() );
 
     const std::string message = "Hello, this is a test message without AAD!";
-    std::vector< uint8_t > message_bytes( message.begin(), message.end() );
+    std::vector< uint8_t > messageBytes( message.begin(), message.end() );
 
-    libBLS::AesGcmCipher cipher{ random_aes_key };
+    libBLS::AesGcmCipher cipher{ randomAesKey };
 
     // Encrypt without AAD (backward compatible)
-    auto ciphertext = cipher.encrypt( message_bytes );
+    auto ciphertext = cipher.encrypt( messageBytes );
 
     // Decrypt without AAD - should succeed
-    auto decrypted_text = cipher.decrypt( ciphertext );
-    BOOST_REQUIRE( decrypted_text == message_bytes );
+    auto decryptedText = cipher.decrypt( ciphertext );
+    BOOST_REQUIRE( decryptedText == messageBytes );
 
     // Encrypt without AAD, try to decrypt with AAD - should fail
-    auto ciphertext2 = cipher.encrypt( message_bytes, std::nullopt );
-    std::vector< uint8_t > fake_aad = { 0x01, 0x02, 0x03 };
-    BOOST_REQUIRE_THROW( cipher.decrypt( ciphertext2, fake_aad ), std::runtime_error );
+    auto ciphertext2 = cipher.encrypt( messageBytes, std::nullopt );
+    std::vector< uint8_t > fakeAad = { 0x01, 0x02, 0x03 };
+    BOOST_REQUIRE_THROW( cipher.decrypt( ciphertext2, fakeAad ), std::runtime_error );
 }
 
 BOOST_AUTO_TEST_CASE( AESWithEmptyAAD ) {
     libBLS::ThresholdUtils::initRAND();
-    libBLS::AES256Key random_aes_key;
-    RAND_bytes( random_aes_key.data(), random_aes_key.size() );
+    libBLS::AES256Key randomAesKey;
+    RAND_bytes( randomAesKey.data(), randomAesKey.size() );
 
     const std::string message = "Hello, this is a test message with empty AAD!";
-    std::vector< uint8_t > message_bytes( message.begin(), message.end() );
+    std::vector< uint8_t > messageBytes( message.begin(), message.end() );
 
     // Empty AAD (different from nullopt)
     std::vector< uint8_t > empty_aad = {};
 
-    libBLS::AesGcmCipher cipher{ random_aes_key };
+    libBLS::AesGcmCipher cipher{ randomAesKey };
 
     // Encrypt with empty AAD
-    auto ciphertext = cipher.encrypt( message_bytes, empty_aad );
+    auto ciphertext = cipher.encrypt( messageBytes, empty_aad );
 
     // Decrypt with empty AAD - should succeed
-    auto decrypted_text = cipher.decrypt( ciphertext, empty_aad );
-    BOOST_REQUIRE( decrypted_text == message_bytes );
+    auto decryptedText = cipher.decrypt( ciphertext, empty_aad );
+    BOOST_REQUIRE( decryptedText == messageBytes );
 
     // Empty AAD should behave the same as nullopt
-    auto decrypted_text2 = cipher.decrypt( ciphertext, std::nullopt );
-    BOOST_REQUIRE( decrypted_text2 == message_bytes );
+    auto decryptedText2 = cipher.decrypt( ciphertext, std::nullopt );
+    BOOST_REQUIRE( decryptedText2 == messageBytes );
 }
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -222,43 +222,43 @@ BOOST_AUTO_TEST_CASE( CipheredKey ) {
     for ( size_t i = 0; i < 20; i++ ) {
         // random key data
         libBLS::algebra::G2Point u = libBLS::algebra::G2Point::random();
-        libBLS::AES256Key ciphered_key;
-        RAND_bytes( ciphered_key.data(), ciphered_key.size() );
+        libBLS::AES256Key cipheredKey;
+        RAND_bytes( cipheredKey.data(), cipheredKey.size() );
         libBLS::algebra::G1Point w = libBLS::algebra::G1Point::random();
 
         // check constructor
-        libBLS::CipheredKey key = libBLS::CipheredKey( u, ciphered_key, w );
+        libBLS::CipheredKey key = libBLS::CipheredKey( u, cipheredKey, w );
 
         BOOST_REQUIRE( key.U == u );
-        BOOST_REQUIRE( key.V == ciphered_key );
+        BOOST_REQUIRE( key.V == cipheredKey );
         BOOST_REQUIRE( key.W == w );
 
         // convert to bytes & back
         std::array< uint8_t, libBLS::CipheredKey::CIPHERED_KEY_SIZE_BYTES > bytes = key.toBytes();
-        libBLS::CipheredKey restored_key = libBLS::CipheredKey::fromBytes( bytes );
+        libBLS::CipheredKey restoredKey = libBLS::CipheredKey::fromBytes( bytes );
 
-        BOOST_REQUIRE( key == restored_key );
+        BOOST_REQUIRE( key == restoredKey );
     }
 }
 
 BOOST_AUTO_TEST_CASE( CipheredKeyException ) {
     // zero u element
     libBLS::algebra::G2Point u = libBLS::algebra::G2Point::identity();
-    libBLS::AES256Key ciphered_key;
-    RAND_bytes( ciphered_key.data(), ciphered_key.size() );
+    libBLS::AES256Key cipheredKey;
+    RAND_bytes( cipheredKey.data(), cipheredKey.size() );
     libBLS::algebra::G1Point w = libBLS::algebra::G1Point::random();
     BOOST_REQUIRE_THROW(
-        libBLS::CipheredKey( u, ciphered_key, w ), libBLS::ThresholdUtils::IsNotWellFormed );
+        libBLS::CipheredKey( u, cipheredKey, w ), libBLS::ThresholdUtils::IsNotWellFormed );
 
     // zero w element
     u = libBLS::algebra::G2Point::random();
     w = libBLS::algebra::G1Point::identity();
     BOOST_REQUIRE_THROW(
-        libBLS::CipheredKey( u, ciphered_key, w ), libBLS::ThresholdUtils::IsNotWellFormed );
+        libBLS::CipheredKey( u, cipheredKey, w ), libBLS::ThresholdUtils::IsNotWellFormed );
 
     // correct ciphered key, but changed U mid-execution
     w = libBLS::algebra::G1Point::random();
-    libBLS::CipheredKey key = libBLS::CipheredKey( u, ciphered_key, w );
+    libBLS::CipheredKey key = libBLS::CipheredKey( u, cipheredKey, w );
     key.U = libBLS::algebra::G2Point::identity();
     BOOST_REQUIRE_THROW( key.validate(), libBLS::ThresholdUtils::IsNotWellFormed );
 
@@ -272,11 +272,11 @@ BOOST_AUTO_TEST_CASE( Ciphertext ) {
     for ( size_t i = 0; i < 20; i++ ) {
         // random key data
         libBLS::algebra::G2Point u = libBLS::algebra::G2Point::random();
-        libBLS::AES256Key ciphered_key;
-        RAND_bytes( ciphered_key.data(), ciphered_key.size() );
+        libBLS::AES256Key cipheredKey;
+        RAND_bytes( cipheredKey.data(), cipheredKey.size() );
         libBLS::algebra::G1Point w = libBLS::algebra::G1Point::random();
         // convert to bytes & back
-        libBLS::CipheredKey key = libBLS::CipheredKey( u, ciphered_key, w );
+        libBLS::CipheredKey key = libBLS::CipheredKey( u, cipheredKey, w );
 
         // random 1000 bytes
         std::vector< uint8_t > data;
@@ -356,40 +356,40 @@ BOOST_AUTO_TEST_CASE( CiphertextException ) {
 BOOST_AUTO_TEST_CASE( SimpleEncryption ) {
     libBLS::TE te_instance = libBLS::TE( 1, 1 );
 
-    libBLS::AES256Key random_aes_key;
-    RAND_bytes( random_aes_key.data(), random_aes_key.size() );
+    libBLS::AES256Key randomAesKey;
+    RAND_bytes( randomAesKey.data(), randomAesKey.size() );
 
-    libBLS::algebra::FrScalar secret_key = libBLS::algebra::FrScalar::random();
+    libBLS::algebra::FrScalar secretKey = libBLS::algebra::FrScalar::random();
 
-    libBLS::algebra::G2Point public_key = secret_key * libBLS::algebra::G2Point::generator();
+    libBLS::algebra::G2Point publicKey = secretKey * libBLS::algebra::G2Point::generator();
 
-    auto result = te_instance.getCiphertext( random_aes_key, public_key );
+    auto result = te_instance.getCiphertext( randomAesKey, publicKey );
 
     // one decrypt share at a time
     for ( const auto& cipheredKey : result.ciphertext ) {
         std::vector< libBLS::algebra::G2Point > shares1;
 
-        libBLS::algebra::G2Point decryption_share =
-            te_instance.getDecryptionShare( cipheredKey, secret_key );
-        shares1.push_back( decryption_share );
+        libBLS::algebra::G2Point decryptionShare =
+            te_instance.getDecryptionShare( cipheredKey, secretKey );
+        shares1.push_back( decryptionShare );
 
         // standalone validation
-        BOOST_REQUIRE( te_instance.Verify( cipheredKey, decryption_share, public_key ) );
+        BOOST_REQUIRE( te_instance.Verify( cipheredKey, decryptionShare, publicKey ) );
 
         // batched decryption - optimistic
         std::vector< libBLS::CipheredKey > cipheredKeys = { cipheredKey };
-        std::vector< bool > verifications_key1 =
-            te_instance.VerifyBatch( cipheredKeys, shares1, { public_key } );
+        std::vector< bool > verificationsKey1 =
+            te_instance.VerifyBatch( cipheredKeys, shares1, { publicKey } );
         BOOST_REQUIRE( std::all_of(
-            verifications_key1.begin(), verifications_key1.end(), []( bool v ) { return v; } ) );
+            verificationsKey1.begin(), verificationsKey1.end(), []( bool v ) { return v; } ) );
 
 
         std::vector< std::pair< libBLS::algebra::G2Point, size_t > > shares;
-        shares.push_back( std::make_pair( decryption_share, size_t( 1 ) ) );
+        shares.push_back( std::make_pair( decryptionShare, size_t( 1 ) ) );
 
         libBLS::AES256Key res = te_instance.CombineShares( cipheredKey, shares );
 
-        BOOST_REQUIRE( res == random_aes_key );
+        BOOST_REQUIRE( res == randomAesKey );
     }
 }
 
@@ -397,35 +397,34 @@ BOOST_AUTO_TEST_CASE( SimpleEncryptionWithAES ) {
     libBLS::TE te_instance = libBLS::TE( 1, 1 );
 
     std::string message = "Hello, SKALE users and fans, gl!Hello, SKALE users and fans, gl!";
-    std::vector< uint8_t > message_bytes( message.begin(), message.end() );
+    std::vector< uint8_t > messageBytes( message.begin(), message.end() );
 
-    libBLS::algebra::FrScalar secret_key = libBLS::algebra::FrScalar::random();
+    libBLS::algebra::FrScalar secretKey = libBLS::algebra::FrScalar::random();
 
-    libBLS::algebra::G2Point public_key = secret_key * libBLS::algebra::G2Point::generator();
+    libBLS::algebra::G2Point publicKey = secretKey * libBLS::algebra::G2Point::generator();
 
-    libBLS::CipherResult ciphertext_with_aes =
-        te_instance.encryptWithAES( message_bytes, public_key );
+    libBLS::CipherResult ciphertextWithAes = te_instance.encryptWithAES( messageBytes, publicKey );
 
-    auto encrypted_message = ciphertext_with_aes.ciphertext->getData();
-    for ( const auto& cipheredKey : ciphertext_with_aes.ciphertext->getKeys() ) {
-        libBLS::algebra::G2Point decryption_share =
-            te_instance.getDecryptionShare( cipheredKey, secret_key );
+    auto encryptedMessage = ciphertextWithAes.ciphertext->getData();
+    for ( const auto& cipheredKey : ciphertextWithAes.ciphertext->getKeys() ) {
+        libBLS::algebra::G2Point decryptionShare =
+            te_instance.getDecryptionShare( cipheredKey, secretKey );
 
-        BOOST_REQUIRE( te_instance.Verify( cipheredKey, decryption_share, public_key ) );
+        BOOST_REQUIRE( te_instance.Verify( cipheredKey, decryptionShare, publicKey ) );
 
         std::vector< std::pair< libBLS::algebra::G2Point, size_t > > shares;
-        shares.push_back( std::make_pair( decryption_share, size_t( 1 ) ) );
+        shares.push_back( std::make_pair( decryptionShare, size_t( 1 ) ) );
 
-        libBLS::AES256Key decrypted_aes_key = te_instance.CombineShares( cipheredKey, shares );
+        libBLS::AES256Key decryptedAesKey = te_instance.CombineShares( cipheredKey, shares );
 
-        libBLS::AesGcmCipher aesGcmCipher{ decrypted_aes_key };
-        std::vector< uint8_t > plaintext = aesGcmCipher.decrypt( encrypted_message );
+        libBLS::AesGcmCipher aesGcmCipher{ decryptedAesKey };
+        std::vector< uint8_t > plaintext = aesGcmCipher.decrypt( encryptedMessage );
 
         // append random secret to end of original message
-        libBLS::RandSecret rand_secret = ciphertext_with_aes.random_secret;
-        message_bytes.insert( message_bytes.end(), rand_secret.begin(), rand_secret.end() );
+        libBLS::RandSecret randSecret = ciphertextWithAes.randomSecret;
+        messageBytes.insert( messageBytes.end(), randSecret.begin(), randSecret.end() );
 
-        BOOST_REQUIRE( plaintext == message_bytes );
+        BOOST_REQUIRE( plaintext == messageBytes );
     }
 }
 
@@ -433,41 +432,41 @@ BOOST_AUTO_TEST_CASE( EncryptionWithAES_AAD ) {
     libBLS::TE te_instance = libBLS::TE( 1, 1 );
 
     std::string message = "Hello, SKALE users! This is a test with AAD!";
-    std::vector< uint8_t > message_bytes( message.begin(), message.end() );
+    std::vector< uint8_t > messageBytes( message.begin(), message.end() );
 
     // AAD that binds the ciphertext to a specific context (e.g., contract address)
     std::vector< uint8_t > aad = { 0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE };
 
-    libBLS::algebra::FrScalar secret_key = libBLS::algebra::FrScalar::random();
-    libBLS::algebra::G2Point public_key = secret_key * libBLS::algebra::G2Point::generator();
+    libBLS::algebra::FrScalar secretKey = libBLS::algebra::FrScalar::random();
+    libBLS::algebra::G2Point publicKey = secretKey * libBLS::algebra::G2Point::generator();
 
     // Encrypt with AAD
-    libBLS::CipherResult ciphertext_with_aes =
-        te_instance.encryptWithAES( message_bytes, public_key, aad );
+    libBLS::CipherResult ciphertextWithAes =
+        te_instance.encryptWithAES( messageBytes, publicKey, aad );
 
-    auto encrypted_message = ciphertext_with_aes.ciphertext->getData();
+    auto encryptedMessage = ciphertextWithAes.ciphertext->getData();
 
-    for ( const auto& cipheredKey : ciphertext_with_aes.ciphertext->getKeys() ) {
-        libBLS::algebra::G2Point decryption_share =
-            te_instance.getDecryptionShare( cipheredKey, secret_key );
+    for ( const auto& cipheredKey : ciphertextWithAes.ciphertext->getKeys() ) {
+        libBLS::algebra::G2Point decryptionShare =
+            te_instance.getDecryptionShare( cipheredKey, secretKey );
 
-        BOOST_REQUIRE( te_instance.Verify( cipheredKey, decryption_share, public_key ) );
+        BOOST_REQUIRE( te_instance.Verify( cipheredKey, decryptionShare, publicKey ) );
 
         std::vector< std::pair< libBLS::algebra::G2Point, size_t > > shares;
-        shares.push_back( std::make_pair( decryption_share, size_t( 1 ) ) );
+        shares.push_back( std::make_pair( decryptionShare, size_t( 1 ) ) );
 
-        libBLS::AES256Key decrypted_aes_key = te_instance.CombineShares( cipheredKey, shares );
+        libBLS::AES256Key decryptedAesKey = te_instance.CombineShares( cipheredKey, shares );
 
         // Decrypt with the same AAD - should succeed
-        libBLS::AesGcmCipher aesGcmCipher{ decrypted_aes_key };
-        std::vector< uint8_t > plaintext = aesGcmCipher.decrypt( encrypted_message, aad );
+        libBLS::AesGcmCipher aesGcmCipher{ decryptedAesKey };
+        std::vector< uint8_t > plaintext = aesGcmCipher.decrypt( encryptedMessage, aad );
 
         // Append random secret to end of original message for comparison
-        libBLS::RandSecret rand_secret = ciphertext_with_aes.random_secret;
-        std::vector< uint8_t > expected_message = message_bytes;
-        expected_message.insert( expected_message.end(), rand_secret.begin(), rand_secret.end() );
+        libBLS::RandSecret randSecret = ciphertextWithAes.randomSecret;
+        std::vector< uint8_t > expectedMessage = messageBytes;
+        expectedMessage.insert( expectedMessage.end(), randSecret.begin(), randSecret.end() );
 
-        BOOST_REQUIRE( plaintext == expected_message );
+        BOOST_REQUIRE( plaintext == expectedMessage );
     }
 }
 
@@ -475,39 +474,39 @@ BOOST_AUTO_TEST_CASE( EncryptionWithAES_WrongAAD ) {
     libBLS::TE te_instance = libBLS::TE( 1, 1 );
 
     std::string message = "Hello, SKALE users! This is a test with AAD!";
-    std::vector< uint8_t > message_bytes( message.begin(), message.end() );
+    std::vector< uint8_t > messageBytes( message.begin(), message.end() );
 
     // AAD used for encryption
     std::vector< uint8_t > aad = { 0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE };
     // Wrong AAD for decryption
     std::vector< uint8_t > wrong_aad = { 0x01, 0x02, 0x03, 0x04 };
 
-    libBLS::algebra::FrScalar secret_key = libBLS::algebra::FrScalar::random();
-    libBLS::algebra::G2Point public_key = secret_key * libBLS::algebra::G2Point::generator();
+    libBLS::algebra::FrScalar secretKey = libBLS::algebra::FrScalar::random();
+    libBLS::algebra::G2Point publicKey = secretKey * libBLS::algebra::G2Point::generator();
 
     // Encrypt with AAD
-    libBLS::CipherResult ciphertext_with_aes =
-        te_instance.encryptWithAES( message_bytes, public_key, aad );
+    libBLS::CipherResult ciphertextWithAes =
+        te_instance.encryptWithAES( messageBytes, publicKey, aad );
 
-    auto encrypted_message = ciphertext_with_aes.ciphertext->getData();
+    auto encryptedMessage = ciphertextWithAes.ciphertext->getData();
 
-    for ( const auto& cipheredKey : ciphertext_with_aes.ciphertext->getKeys() ) {
-        libBLS::algebra::G2Point decryption_share =
-            te_instance.getDecryptionShare( cipheredKey, secret_key );
+    for ( const auto& cipheredKey : ciphertextWithAes.ciphertext->getKeys() ) {
+        libBLS::algebra::G2Point decryptionShare =
+            te_instance.getDecryptionShare( cipheredKey, secretKey );
 
         std::vector< std::pair< libBLS::algebra::G2Point, size_t > > shares;
-        shares.push_back( std::make_pair( decryption_share, size_t( 1 ) ) );
+        shares.push_back( std::make_pair( decryptionShare, size_t( 1 ) ) );
 
-        libBLS::AES256Key decrypted_aes_key = te_instance.CombineShares( cipheredKey, shares );
+        libBLS::AES256Key decryptedAesKey = te_instance.CombineShares( cipheredKey, shares );
 
         // Decrypt with wrong AAD - should fail
-        libBLS::AesGcmCipher aesGcmCipher{ decrypted_aes_key };
+        libBLS::AesGcmCipher aesGcmCipher{ decryptedAesKey };
         BOOST_REQUIRE_THROW(
-            aesGcmCipher.decrypt( encrypted_message, wrong_aad ), std::runtime_error );
+            aesGcmCipher.decrypt( encryptedMessage, wrong_aad ), std::runtime_error );
 
         // Decrypt without AAD - should also fail
         BOOST_REQUIRE_THROW(
-            aesGcmCipher.decrypt( encrypted_message, std::nullopt ), std::runtime_error );
+            aesGcmCipher.decrypt( encryptedMessage, std::nullopt ), std::runtime_error );
     }
 }
 
@@ -515,30 +514,30 @@ BOOST_AUTO_TEST_CASE( encryptionWithAESWrongKey ) {
     libBLS::TE te_instance = libBLS::TE( 1, 1 );
 
     std::string message = "Hello, SKALE users and fans, gl!Hello, SKALE users and fans, gl!";
-    std::vector< uint8_t > message_bytes( message.begin(), message.end() );
+    std::vector< uint8_t > messageBytes( message.begin(), message.end() );
 
-    libBLS::algebra::FrScalar secret_key = libBLS::algebra::FrScalar::random();
+    libBLS::algebra::FrScalar secretKey = libBLS::algebra::FrScalar::random();
 
-    libBLS::algebra::G2Point public_key = secret_key * libBLS::algebra::G2Point::generator();
+    libBLS::algebra::G2Point publicKey = secretKey * libBLS::algebra::G2Point::generator();
 
-    auto ciphertext_with_aes = te_instance.encryptWithAES( message_bytes, public_key );
+    auto ciphertextWithAes = te_instance.encryptWithAES( messageBytes, publicKey );
 
-    auto encrypted_message = ciphertext_with_aes.ciphertext->getData();
-    for ( const auto& cipheredKey : ciphertext_with_aes.ciphertext->getKeys() ) {
-        libBLS::algebra::G2Point decryption_share =
-            te_instance.getDecryptionShare( cipheredKey, secret_key );
+    auto encryptedMessage = ciphertextWithAes.ciphertext->getData();
+    for ( const auto& cipheredKey : ciphertextWithAes.ciphertext->getKeys() ) {
+        libBLS::algebra::G2Point decryptionShare =
+            te_instance.getDecryptionShare( cipheredKey, secretKey );
 
-        BOOST_REQUIRE( te_instance.Verify( cipheredKey, decryption_share, public_key ) );
+        BOOST_REQUIRE( te_instance.Verify( cipheredKey, decryptionShare, publicKey ) );
 
         std::vector< std::pair< libBLS::algebra::G2Point, size_t > > shares;
-        shares.push_back( std::make_pair( decryption_share, size_t( 1 ) ) );
+        shares.push_back( std::make_pair( decryptionShare, size_t( 1 ) ) );
 
-        libBLS::AES256Key random_aes_key;
-        RAND_bytes( random_aes_key.data(), random_aes_key.size() );
+        libBLS::AES256Key randomAesKey;
+        RAND_bytes( randomAesKey.data(), randomAesKey.size() );
 
 
-        libBLS::AesGcmCipher cipher{ random_aes_key };
-        BOOST_REQUIRE_THROW( cipher.decrypt( encrypted_message ), std::runtime_error );
+        libBLS::AesGcmCipher cipher{ randomAesKey };
+        BOOST_REQUIRE_THROW( cipher.decrypt( encryptedMessage ), std::runtime_error );
     }
 }
 
@@ -546,33 +545,31 @@ BOOST_AUTO_TEST_CASE( encryptionWithAESWrongCiphertext ) {
     libBLS::TE te_instance = libBLS::TE( 1, 1 );
 
     std::string message = "Hello, SKALE users and fans, gl!Hello, SKALE users and fans, gl!";
-    std::vector< uint8_t > message_bytes( message.begin(), message.end() );
+    std::vector< uint8_t > messageBytes( message.begin(), message.end() );
 
-    libBLS::algebra::FrScalar secret_key = libBLS::algebra::FrScalar::random();
+    libBLS::algebra::FrScalar secretKey = libBLS::algebra::FrScalar::random();
 
-    libBLS::algebra::G2Point public_key = secret_key * libBLS::algebra::G2Point::generator();
+    libBLS::algebra::G2Point publicKey = secretKey * libBLS::algebra::G2Point::generator();
 
-    libBLS::CipherResult ciphertext_with_aes =
-        te_instance.encryptWithAES( message_bytes, public_key );
+    libBLS::CipherResult ciphertextWithAes = te_instance.encryptWithAES( messageBytes, publicKey );
 
-    for ( const auto& cipheredKey : ciphertext_with_aes.ciphertext->getKeys() ) {
-        libBLS::algebra::G2Point decryption_share =
-            te_instance.getDecryptionShare( cipheredKey, secret_key );
-        BOOST_REQUIRE( te_instance.Verify( cipheredKey, decryption_share, public_key ) );
+    for ( const auto& cipheredKey : ciphertextWithAes.ciphertext->getKeys() ) {
+        libBLS::algebra::G2Point decryptionShare =
+            te_instance.getDecryptionShare( cipheredKey, secretKey );
+        BOOST_REQUIRE( te_instance.Verify( cipheredKey, decryptionShare, publicKey ) );
 
         std::vector< std::pair< libBLS::algebra::G2Point, size_t > > shares;
-        shares.push_back( std::make_pair( decryption_share, size_t( 1 ) ) );
-        libBLS::AES256Key decrypted_aes_key = te_instance.CombineShares( cipheredKey, shares );
+        shares.push_back( std::make_pair( decryptionShare, size_t( 1 ) ) );
+        libBLS::AES256Key decryptedAesKey = te_instance.CombineShares( cipheredKey, shares );
 
-        std::string bad_message =
-            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
-        std::vector< uint8_t > bad_message_bytes( message.begin(), message.end() );
+        std::string badMessage = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        std::vector< uint8_t > badMessageBytes( message.begin(), message.end() );
 
-        auto bad_encrypted_message =
-            te_instance.encryptWithAES( bad_message_bytes, public_key ).ciphertext->getData();
+        auto bad_encryptedMessage =
+            te_instance.encryptWithAES( badMessageBytes, publicKey ).ciphertext->getData();
 
-        libBLS::AesGcmCipher cipher{ decrypted_aes_key };
-        BOOST_REQUIRE_THROW( cipher.decrypt( bad_encrypted_message ), std::runtime_error );
+        libBLS::AesGcmCipher cipher{ decryptedAesKey };
+        BOOST_REQUIRE_THROW( cipher.decrypt( bad_encryptedMessage ), std::runtime_error );
     }
 }
 
@@ -580,40 +577,40 @@ BOOST_AUTO_TEST_CASE( EncryptionCipherToBytes ) {
     libBLS::TE te_instance = libBLS::TE( 1, 1 );
 
     std::string message = "Hello, SKALE users and fans, gl!Hello, SKALE users and fans, gl!";
-    std::vector< uint8_t > message_bytes( message.begin(), message.end() );
+    std::vector< uint8_t > messageBytes( message.begin(), message.end() );
 
-    libBLS::algebra::FrScalar secret_key = libBLS::algebra::FrScalar::random();
+    libBLS::algebra::FrScalar secretKey = libBLS::algebra::FrScalar::random();
 
-    libBLS::algebra::G2Point public_key = secret_key * libBLS::algebra::G2Point::generator();
+    libBLS::algebra::G2Point publicKey = secretKey * libBLS::algebra::G2Point::generator();
 
-    std::string common_public_str = public_key.toString( libBLS::Base::HEXA );
-    auto result = te_instance.encryptMessage( message_bytes, common_public_str );
-    libBLS::RandSecret rand_secret = result.second;
+    std::string commonPublicStr = publicKey.toString( libBLS::Base::HEXA );
+    auto result = te_instance.encryptMessage( messageBytes, commonPublicStr );
+    libBLS::RandSecret randSecret = result.second;
 
-    std::vector< uint8_t > encrypted_msg_bytes =
+    std::vector< uint8_t > encryptedMsgBytes =
         libBLS::ThresholdUtils::hexCStringToBytes( result.first.c_str() );
 
-    libBLS::Ciphertext ciphertext = libBLS::Ciphertext::fromBytes( encrypted_msg_bytes );
-    auto encrypted_message = ciphertext.getData();
+    libBLS::Ciphertext ciphertext = libBLS::Ciphertext::fromBytes( encryptedMsgBytes );
+    auto encryptedMessage = ciphertext.getData();
 
     for ( const auto& cipheredkey : ciphertext.getKeys() ) {
-        libBLS::algebra::G2Point decryption_share =
-            te_instance.getDecryptionShare( cipheredkey, secret_key );
+        libBLS::algebra::G2Point decryptionShare =
+            te_instance.getDecryptionShare( cipheredkey, secretKey );
 
-        BOOST_REQUIRE( te_instance.Verify( cipheredkey, decryption_share, public_key ) );
+        BOOST_REQUIRE( te_instance.Verify( cipheredkey, decryptionShare, publicKey ) );
 
         std::vector< std::pair< libBLS::algebra::G2Point, size_t > > shares;
-        shares.push_back( std::make_pair( decryption_share, size_t( 1 ) ) );
+        shares.push_back( std::make_pair( decryptionShare, size_t( 1 ) ) );
 
-        libBLS::AES256Key decrypted_aes_key = te_instance.CombineShares( cipheredkey, shares );
+        libBLS::AES256Key decryptedAesKey = te_instance.CombineShares( cipheredkey, shares );
 
-        libBLS::AesGcmCipher cipher{ decrypted_aes_key };
-        std::vector< uint8_t > plaintext = cipher.decrypt( encrypted_message );
+        libBLS::AesGcmCipher cipher{ decryptedAesKey };
+        std::vector< uint8_t > plaintext = cipher.decrypt( encryptedMessage );
 
         // append random secret to the message
-        message_bytes.insert( message_bytes.end(), rand_secret.begin(), rand_secret.end() );
+        messageBytes.insert( messageBytes.end(), randSecret.begin(), randSecret.end() );
 
-        BOOST_REQUIRE( plaintext == message_bytes );
+        BOOST_REQUIRE( plaintext == messageBytes );
     }
 }
 
@@ -630,7 +627,7 @@ BOOST_AUTO_TEST_CASE( ThresholdEncryptionReal ) {
         }
     }
 
-    std::vector< libBLS::algebra::FrScalar > secret_keys( n );
+    std::vector< libBLS::algebra::FrScalar > secretKeys( n );
 
     for ( size_t i = 0; i < 16; ++i ) {
         libBLS::algebra::FrScalar sk = libBLS::algebra::FrScalar::zero();
@@ -645,35 +642,35 @@ BOOST_AUTO_TEST_CASE( ThresholdEncryptionReal ) {
             sk += tmp4;
         }
 
-        secret_keys[i] = sk;
+        secretKeys[i] = sk;
     }
 
-    libBLS::algebra::FrScalar common_secret = coeffs[0];
+    libBLS::algebra::FrScalar commonSecret = coeffs[0];
 
-    libBLS::algebra::G2Point common_public = common_secret * libBLS::algebra::G2Point::generator();
+    libBLS::algebra::G2Point commonPublic = commonSecret * libBLS::algebra::G2Point::generator();
 
     libBLS::AES256Key key;
     RAND_bytes( key.data(), key.size() );
 
-    auto result = obj.getCiphertext( key, common_public );
+    auto result = obj.getCiphertext( key, commonPublic );
 
     for ( const auto& cipheredKey : result.ciphertext ) {
         std::vector< std::pair< libBLS::algebra::G2Point, size_t > > shares( t );
-        std::vector< libBLS::algebra::G2Point > decrypted_shares( t );
+        std::vector< libBLS::algebra::G2Point > decryptedShares( t );
         std::vector< libBLS::algebra::G2Point > pubKeys( t );
 
         for ( size_t i = 0; i < t; ++i ) {
             libBLS::algebra::G2Point decrypted =
-                obj.getDecryptionShare( cipheredKey, secret_keys[i] );
+                obj.getDecryptionShare( cipheredKey, secretKeys[i] );
 
-            decrypted_shares[i] = decrypted;
+            decryptedShares[i] = decrypted;
 
-            libBLS::algebra::G2Point public_key =
-                secret_keys[i] * libBLS::algebra::G2Point::generator();
+            libBLS::algebra::G2Point publicKey =
+                secretKeys[i] * libBLS::algebra::G2Point::generator();
 
-            pubKeys[i] = public_key;
+            pubKeys[i] = publicKey;
 
-            BOOST_REQUIRE( obj.Verify( cipheredKey, decrypted, public_key ) );
+            BOOST_REQUIRE( obj.Verify( cipheredKey, decrypted, publicKey ) );
 
             shares[i].first = decrypted;
 
@@ -684,7 +681,7 @@ BOOST_AUTO_TEST_CASE( ThresholdEncryptionReal ) {
         std::vector< libBLS::CipheredKey > keysBatch;
         keysBatch.push_back( cipheredKey );
 
-        auto verifications = obj.VerifyBatch( keysBatch, decrypted_shares, pubKeys );
+        auto verifications = obj.VerifyBatch( keysBatch, decryptedShares, pubKeys );
         BOOST_REQUIRE(
             std::all_of( verifications.begin(), verifications.end(), []( bool v ) { return v; } ) );
 
@@ -712,7 +709,7 @@ BOOST_AUTO_TEST_CASE( ThresholdEncryptionRandomPK ) {
         }
     }
 
-    std::vector< libBLS::algebra::FrScalar > secret_keys( 16 );
+    std::vector< libBLS::algebra::FrScalar > secretKeys( 16 );
 
     for ( size_t i = 0; i < 16; ++i ) {
         libBLS::algebra::FrScalar sk = libBLS::algebra::FrScalar::zero();
@@ -727,15 +724,15 @@ BOOST_AUTO_TEST_CASE( ThresholdEncryptionRandomPK ) {
             sk += tmp4;
         }
 
-        secret_keys[i] = sk;
+        secretKeys[i] = sk;
     }
 
-    libBLS::algebra::G2Point common_public = libBLS::algebra::G2Point::random();
+    libBLS::algebra::G2Point commonPublic = libBLS::algebra::G2Point::random();
 
     libBLS::AES256Key key;
     RAND_bytes( key.data(), key.size() );
 
-    auto result = obj.getCiphertext( key, common_public );
+    auto result = obj.getCiphertext( key, commonPublic );
 
     std::vector< std::pair< libBLS::algebra::G2Point, size_t > > shares( 11 );
 
@@ -743,11 +740,11 @@ BOOST_AUTO_TEST_CASE( ThresholdEncryptionRandomPK ) {
     for ( const auto& cipheredKey : result.ciphertext ) {
         for ( size_t i = 0; i < 11; ++i ) {
             libBLS::algebra::G2Point decrypted =
-                obj.getDecryptionShare( cipheredKey, secret_keys[i] );
-            libBLS::algebra::G2Point public_key =
-                secret_keys[i] * libBLS::algebra::G2Point::generator();
+                obj.getDecryptionShare( cipheredKey, secretKeys[i] );
+            libBLS::algebra::G2Point publicKey =
+                secretKeys[i] * libBLS::algebra::G2Point::generator();
 
-            BOOST_REQUIRE( obj.Verify( cipheredKey, decrypted, public_key ) );
+            BOOST_REQUIRE( obj.Verify( cipheredKey, decrypted, publicKey ) );
 
             shares[i].first = decrypted;
 
@@ -771,7 +768,7 @@ BOOST_AUTO_TEST_CASE( ThresholdEncryptionRandomSK ) {
         }
     }
 
-    std::vector< libBLS::algebra::FrScalar > secret_keys( 16 );
+    std::vector< libBLS::algebra::FrScalar > secretKeys( 16 );
 
     for ( size_t i = 0; i < 16; ++i ) {
         libBLS::algebra::FrScalar sk = libBLS::algebra::FrScalar::zero();
@@ -786,33 +783,33 @@ BOOST_AUTO_TEST_CASE( ThresholdEncryptionRandomSK ) {
             sk += tmp4;
         }
 
-        // let secret_key[7] be a random generated value instead of correctly generated
+        // let secretKey[7] be a random generated value instead of correctly generated
         if ( i == 7 ) {
             sk = libBLS::algebra::FrScalar::random();
         }
 
-        secret_keys[i] = sk;
+        secretKeys[i] = sk;
     }
 
-    libBLS::algebra::FrScalar common_secret = coeffs[0];
+    libBLS::algebra::FrScalar commonSecret = coeffs[0];
 
-    libBLS::algebra::G2Point common_public = common_secret * libBLS::algebra::G2Point::generator();
+    libBLS::algebra::G2Point commonPublic = commonSecret * libBLS::algebra::G2Point::generator();
 
     libBLS::AES256Key key;
     RAND_bytes( key.data(), key.size() );
 
-    auto result = obj.getCiphertext( key, common_public );
+    auto result = obj.getCiphertext( key, commonPublic );
 
     for ( const auto& cipheredKey : result.ciphertext ) {
         std::vector< std::pair< libBLS::algebra::G2Point, size_t > > shares( 11 );
 
         for ( size_t i = 0; i < 11; ++i ) {
             libBLS::algebra::G2Point decrypted =
-                obj.getDecryptionShare( cipheredKey, secret_keys[i] );
-            libBLS::algebra::G2Point public_key =
-                secret_keys[i] * libBLS::algebra::G2Point::generator();
+                obj.getDecryptionShare( cipheredKey, secretKeys[i] );
+            libBLS::algebra::G2Point publicKey =
+                secretKeys[i] * libBLS::algebra::G2Point::generator();
 
-            BOOST_REQUIRE( obj.Verify( cipheredKey, decrypted, public_key ) );
+            BOOST_REQUIRE( obj.Verify( cipheredKey, decrypted, publicKey ) );
 
             shares[i].first = decrypted;
 
@@ -836,7 +833,7 @@ BOOST_AUTO_TEST_CASE( ThresholdEncryptionCorruptedCiphertext ) {
         }
     }
 
-    std::vector< libBLS::algebra::FrScalar > secret_keys( 16 );
+    std::vector< libBLS::algebra::FrScalar > secretKeys( 16 );
 
     for ( size_t i = 0; i < 16; ++i ) {
         libBLS::algebra::FrScalar sk = libBLS::algebra::FrScalar::zero();
@@ -851,63 +848,63 @@ BOOST_AUTO_TEST_CASE( ThresholdEncryptionCorruptedCiphertext ) {
             sk += tmp4;
         }
 
-        secret_keys[i] = sk;
+        secretKeys[i] = sk;
     }
 
-    libBLS::algebra::FrScalar common_secret = coeffs[0];
+    libBLS::algebra::FrScalar commonSecret = coeffs[0];
 
-    libBLS::algebra::G2Point common_public = common_secret * libBLS::algebra::G2Point::identity();
+    libBLS::algebra::G2Point commonPublic = commonSecret * libBLS::algebra::G2Point::identity();
 
     libBLS::AES256Key key;
     RAND_bytes( key.data(), key.size() );
 
-    auto result = obj.getCiphertext( key, common_public );
+    auto result = obj.getCiphertext( key, commonPublic );
 
     libBLS::algebra::G1Point rand = libBLS::algebra::G1Point::random();
 
     libBLS::CipheredKey cipheredKeyToCorrupt = result.ciphertext[0];
-    libBLS::CipheredKey corrupted_ciphered_key = { cipheredKeyToCorrupt.U, cipheredKeyToCorrupt.V,
+    libBLS::CipheredKey corruptedCipheredKey = { cipheredKeyToCorrupt.U, cipheredKeyToCorrupt.V,
         rand };
 
     for ( size_t i = 0; i < 11; ++i ) {
         libBLS::algebra::G2Point decryptedWrong =
-            obj.getDecryptionShare( corrupted_ciphered_key, secret_keys[i] );
+            obj.getDecryptionShare( corruptedCipheredKey, secretKeys[i] );
         libBLS::algebra::G2Point decryptedCorrect =
-            obj.getDecryptionShare( cipheredKeyToCorrupt, secret_keys[i] );
+            obj.getDecryptionShare( cipheredKeyToCorrupt, secretKeys[i] );
 
-        libBLS::algebra::G2Point public_key = secret_keys[i] * libBLS::algebra::G2Point::identity();
+        libBLS::algebra::G2Point publicKey = secretKeys[i] * libBLS::algebra::G2Point::identity();
 
         // wrong cipher key, correct decrypted key - should return false
-        BOOST_REQUIRE( !obj.Verify( corrupted_ciphered_key, decryptedCorrect, public_key ) );
+        BOOST_REQUIRE( !obj.Verify( corruptedCipheredKey, decryptedCorrect, publicKey ) );
 
         // wrong decrypted key, correct cipher key - should return false
-        BOOST_REQUIRE( !obj.Verify( cipheredKeyToCorrupt, decryptedWrong, public_key ) );
+        BOOST_REQUIRE( !obj.Verify( cipheredKeyToCorrupt, decryptedWrong, publicKey ) );
     }
 }
 
 BOOST_AUTO_TEST_CASE( LagrangeInterpolationExceptions ) {
     for ( size_t i = 0; i < 100; i++ ) {
-        std::default_random_engine rand_gen( ( unsigned int ) time( 0 ) );
-        size_t num_all = rand_gen() % 15 + 2;
-        size_t num_signed = rand_gen() % ( num_all - 1 ) + 2;
+        std::default_random_engine randGen( ( unsigned int ) time( 0 ) );
+        size_t numAll = randGen() % 15 + 2;
+        size_t numSigned = randGen() % ( numAll - 1 ) + 2;
 
         {
-            libBLS::TE obj( num_signed, num_all );
+            libBLS::TE obj( numSigned, numAll );
             std::vector< size_t > vect;
-            for ( size_t i = 0; i < num_signed - 1; i++ )
+            for ( size_t i = 0; i < numSigned - 1; i++ )
                 vect.push_back( i + 1 );
-            BOOST_REQUIRE_THROW( libBLS::algebra::lagrangeCoeffs( vect, num_signed ),
+            BOOST_REQUIRE_THROW( libBLS::algebra::lagrangeCoeffs( vect, numSigned ),
                 libBLS::ThresholdUtils::IncorrectInput );
         }
 
         {
-            libBLS::TE obj( num_signed, num_all );
+            libBLS::TE obj( numSigned, numAll );
             std::vector< size_t > vect;
-            for ( size_t i = 0; i < num_signed; i++ ) {
+            for ( size_t i = 0; i < numSigned; i++ ) {
                 vect.push_back( i + 1 );
             }
             vect.at( 1 ) = vect.at( 0 );
-            BOOST_REQUIRE_THROW( libBLS::algebra::lagrangeCoeffs( vect, num_signed ),
+            BOOST_REQUIRE_THROW( libBLS::algebra::lagrangeCoeffs( vect, numSigned ),
                 libBLS::ThresholdUtils::IncorrectInput );
         }
     }

--- a/test/unit_tests_te.cpp
+++ b/test/unit_tests_te.cpp
@@ -102,6 +102,117 @@ BOOST_AUTO_TEST_CASE( wrongKey ) {
     BOOST_REQUIRE_THROW( bad_cipher.decrypt( ciphertext ), std::runtime_error );
 }
 
+BOOST_AUTO_TEST_CASE( AESWithAAD ) {
+    libBLS::ThresholdUtils::initRAND();
+    libBLS::AES256Key random_aes_key;
+    RAND_bytes( random_aes_key.data(), random_aes_key.size() );
+
+    const std::string message = "Hello, this is a test message for AAD encryption!";
+    std::vector< uint8_t > message_bytes( message.begin(), message.end() );
+
+    // Create AAD (additional authenticated data)
+    std::vector< uint8_t > aad = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+
+    libBLS::AesGcmCipher cipher{ random_aes_key };
+
+    // Encrypt with AAD
+    auto ciphertext = cipher.encrypt( message_bytes, aad );
+
+    // Decrypt with same AAD - should succeed
+    auto decrypted_text = cipher.decrypt( ciphertext, aad );
+    BOOST_REQUIRE( decrypted_text == message_bytes );
+}
+
+BOOST_AUTO_TEST_CASE( AESWithWrongAAD ) {
+    libBLS::ThresholdUtils::initRAND();
+    libBLS::AES256Key random_aes_key;
+    RAND_bytes( random_aes_key.data(), random_aes_key.size() );
+
+    const std::string message = "Hello, this is a test message for AAD encryption!";
+    std::vector< uint8_t > message_bytes( message.begin(), message.end() );
+
+    // Create AAD
+    std::vector< uint8_t > aad = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+    // Different AAD
+    std::vector< uint8_t > wrong_aad = { 0xFF, 0xFE, 0xFD, 0xFC };
+
+    libBLS::AesGcmCipher cipher{ random_aes_key };
+
+    // Encrypt with AAD
+    auto ciphertext = cipher.encrypt( message_bytes, aad );
+
+    // Decrypt with different AAD - should fail (authentication error)
+    BOOST_REQUIRE_THROW( cipher.decrypt( ciphertext, wrong_aad ), std::runtime_error );
+}
+
+BOOST_AUTO_TEST_CASE( AESWithMissingAAD ) {
+    libBLS::ThresholdUtils::initRAND();
+    libBLS::AES256Key random_aes_key;
+    RAND_bytes( random_aes_key.data(), random_aes_key.size() );
+
+    const std::string message = "Hello, this is a test message for AAD encryption!";
+    std::vector< uint8_t > message_bytes( message.begin(), message.end() );
+
+    // Create AAD
+    std::vector< uint8_t > aad = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+
+    libBLS::AesGcmCipher cipher{ random_aes_key };
+
+    // Encrypt with AAD
+    auto ciphertext = cipher.encrypt( message_bytes, aad );
+
+    // Decrypt without AAD (nullopt) - should fail (authentication error)
+    BOOST_REQUIRE_THROW( cipher.decrypt( ciphertext, std::nullopt ), std::runtime_error );
+}
+
+BOOST_AUTO_TEST_CASE( AESWithoutAAD_BackwardCompatibility ) {
+    libBLS::ThresholdUtils::initRAND();
+    libBLS::AES256Key random_aes_key;
+    RAND_bytes( random_aes_key.data(), random_aes_key.size() );
+
+    const std::string message = "Hello, this is a test message without AAD!";
+    std::vector< uint8_t > message_bytes( message.begin(), message.end() );
+
+    libBLS::AesGcmCipher cipher{ random_aes_key };
+
+    // Encrypt without AAD (backward compatible)
+    auto ciphertext = cipher.encrypt( message_bytes );
+
+    // Decrypt without AAD - should succeed
+    auto decrypted_text = cipher.decrypt( ciphertext );
+    BOOST_REQUIRE( decrypted_text == message_bytes );
+
+    // Encrypt without AAD, try to decrypt with AAD - should fail
+    auto ciphertext2 = cipher.encrypt( message_bytes, std::nullopt );
+    std::vector< uint8_t > fake_aad = { 0x01, 0x02, 0x03 };
+    BOOST_REQUIRE_THROW( cipher.decrypt( ciphertext2, fake_aad ), std::runtime_error );
+}
+
+BOOST_AUTO_TEST_CASE( AESWithEmptyAAD ) {
+    libBLS::ThresholdUtils::initRAND();
+    libBLS::AES256Key random_aes_key;
+    RAND_bytes( random_aes_key.data(), random_aes_key.size() );
+
+    const std::string message = "Hello, this is a test message with empty AAD!";
+    std::vector< uint8_t > message_bytes( message.begin(), message.end() );
+
+    // Empty AAD (different from nullopt)
+    std::vector< uint8_t > empty_aad = {};
+
+    libBLS::AesGcmCipher cipher{ random_aes_key };
+
+    // Encrypt with empty AAD
+    auto ciphertext = cipher.encrypt( message_bytes, empty_aad );
+
+    // Decrypt with empty AAD - should succeed
+    auto decrypted_text = cipher.decrypt( ciphertext, empty_aad );
+    BOOST_REQUIRE( decrypted_text == message_bytes );
+
+    // Empty AAD should behave the same as nullopt
+    auto decrypted_text2 = cipher.decrypt( ciphertext, std::nullopt );
+    BOOST_REQUIRE( decrypted_text2 == message_bytes );
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 
@@ -315,6 +426,86 @@ BOOST_AUTO_TEST_CASE( SimpleEncryptionWithAES ) {
         message_bytes.insert( message_bytes.end(), rand_secret.begin(), rand_secret.end() );
 
         BOOST_REQUIRE( plaintext == message_bytes );
+    }
+}
+
+BOOST_AUTO_TEST_CASE( EncryptionWithAES_AAD ) {
+    libBLS::TE te_instance = libBLS::TE( 1, 1 );
+
+    std::string message = "Hello, SKALE users! This is a test with AAD!";
+    std::vector< uint8_t > message_bytes( message.begin(), message.end() );
+
+    // AAD that binds the ciphertext to a specific context (e.g., contract address)
+    std::vector< uint8_t > aad = { 0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE };
+
+    libBLS::algebra::FrScalar secret_key = libBLS::algebra::FrScalar::random();
+    libBLS::algebra::G2Point public_key = secret_key * libBLS::algebra::G2Point::generator();
+
+    // Encrypt with AAD
+    libBLS::CipherResult ciphertext_with_aes =
+        te_instance.encryptWithAES( message_bytes, public_key, aad );
+
+    auto encrypted_message = ciphertext_with_aes.ciphertext->getData();
+
+    for ( const auto& cipheredKey : ciphertext_with_aes.ciphertext->getKeys() ) {
+        libBLS::algebra::G2Point decryption_share =
+            te_instance.getDecryptionShare( cipheredKey, secret_key );
+
+        BOOST_REQUIRE( te_instance.Verify( cipheredKey, decryption_share, public_key ) );
+
+        std::vector< std::pair< libBLS::algebra::G2Point, size_t > > shares;
+        shares.push_back( std::make_pair( decryption_share, size_t( 1 ) ) );
+
+        libBLS::AES256Key decrypted_aes_key = te_instance.CombineShares( cipheredKey, shares );
+
+        // Decrypt with the same AAD - should succeed
+        libBLS::AesGcmCipher aesGcmCipher{ decrypted_aes_key };
+        std::vector< uint8_t > plaintext = aesGcmCipher.decrypt( encrypted_message, aad );
+
+        // Append random secret to end of original message for comparison
+        libBLS::RandSecret rand_secret = ciphertext_with_aes.random_secret;
+        std::vector< uint8_t > expected_message = message_bytes;
+        expected_message.insert( expected_message.end(), rand_secret.begin(), rand_secret.end() );
+
+        BOOST_REQUIRE( plaintext == expected_message );
+    }
+}
+
+BOOST_AUTO_TEST_CASE( EncryptionWithAES_WrongAAD ) {
+    libBLS::TE te_instance = libBLS::TE( 1, 1 );
+
+    std::string message = "Hello, SKALE users! This is a test with AAD!";
+    std::vector< uint8_t > message_bytes( message.begin(), message.end() );
+
+    // AAD used for encryption
+    std::vector< uint8_t > aad = { 0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE };
+    // Wrong AAD for decryption
+    std::vector< uint8_t > wrong_aad = { 0x01, 0x02, 0x03, 0x04 };
+
+    libBLS::algebra::FrScalar secret_key = libBLS::algebra::FrScalar::random();
+    libBLS::algebra::G2Point public_key = secret_key * libBLS::algebra::G2Point::generator();
+
+    // Encrypt with AAD
+    libBLS::CipherResult ciphertext_with_aes =
+        te_instance.encryptWithAES( message_bytes, public_key, aad );
+
+    auto encrypted_message = ciphertext_with_aes.ciphertext->getData();
+
+    for ( const auto& cipheredKey : ciphertext_with_aes.ciphertext->getKeys() ) {
+        libBLS::algebra::G2Point decryption_share =
+            te_instance.getDecryptionShare( cipheredKey, secret_key );
+
+        std::vector< std::pair< libBLS::algebra::G2Point, size_t > > shares;
+        shares.push_back( std::make_pair( decryption_share, size_t( 1 ) ) );
+
+        libBLS::AES256Key decrypted_aes_key = te_instance.CombineShares( cipheredKey, shares );
+
+        // Decrypt with wrong AAD - should fail
+        libBLS::AesGcmCipher aesGcmCipher{ decrypted_aes_key };
+        BOOST_REQUIRE_THROW( aesGcmCipher.decrypt( encrypted_message, wrong_aad ), std::runtime_error );
+
+        // Decrypt without AAD - should also fail
+        BOOST_REQUIRE_THROW( aesGcmCipher.decrypt( encrypted_message, std::nullopt ), std::runtime_error );
     }
 }
 

--- a/threshold_encryption/AesGcmCipher.cpp
+++ b/threshold_encryption/AesGcmCipher.cpp
@@ -27,8 +27,8 @@
 
 namespace libBLS {
 
-std::vector< uint8_t > AesGcmCipher::encrypt( const std::vector< uint8_t >& plaintext,
-    const std::optional< std::vector< uint8_t > >& aad ) {
+std::vector< uint8_t > AesGcmCipher::encrypt(
+    const std::vector< uint8_t >& plaintext, const std::optional< std::vector< uint8_t > >& aad ) {
     initAES();
 
     // Make sure there is enough space for: IV + plaintext + padding
@@ -65,8 +65,8 @@ std::vector< uint8_t > AesGcmCipher::encrypt( const std::vector< uint8_t >& plai
     // Process AAD if provided (authenticated but not encrypted)
     if ( aad.has_value() && !aad->empty() ) {
         int aad_len = 0;
-        check( EVP_EncryptUpdate( e_ctx.get(), nullptr, &aad_len,
-                   aad->data(), static_cast< int >( aad->size() ) ),
+        check( EVP_EncryptUpdate(
+                   e_ctx.get(), nullptr, &aad_len, aad->data(), static_cast< int >( aad->size() ) ),
             "Failed to process AAD" );
     }
 
@@ -94,8 +94,8 @@ std::vector< uint8_t > AesGcmCipher::encrypt( const std::vector< uint8_t >& plai
     return std::vector< uint8_t >( output );
 }
 
-std::vector< uint8_t > AesGcmCipher::decrypt( const std::vector< uint8_t >& ciphertext,
-    const std::optional< std::vector< uint8_t > >& aad ) {
+std::vector< uint8_t > AesGcmCipher::decrypt(
+    const std::vector< uint8_t >& ciphertext, const std::optional< std::vector< uint8_t > >& aad ) {
     initAES();
 
     constexpr size_t meta = AES_GCM_IV_SIZE + AES_GCM_TAG_SIZE;
@@ -133,8 +133,8 @@ std::vector< uint8_t > AesGcmCipher::decrypt( const std::vector< uint8_t >& ciph
     // Process AAD if provided (must match what was used during encryption)
     if ( aad.has_value() && !aad->empty() ) {
         int aad_len = 0;
-        check( EVP_DecryptUpdate( d_ctx.get(), nullptr, &aad_len,
-                   aad->data(), static_cast< int >( aad->size() ) ),
+        check( EVP_DecryptUpdate(
+                   d_ctx.get(), nullptr, &aad_len, aad->data(), static_cast< int >( aad->size() ) ),
             "Failed to process AAD" );
     }
 

--- a/threshold_encryption/AesGcmCipher.cpp
+++ b/threshold_encryption/AesGcmCipher.cpp
@@ -27,7 +27,8 @@
 
 namespace libBLS {
 
-std::vector< uint8_t > AesGcmCipher::encrypt( const std::vector< uint8_t >& plaintext ) {
+std::vector< uint8_t > AesGcmCipher::encrypt( const std::vector< uint8_t >& plaintext,
+    const std::optional< std::vector< uint8_t > >& aad ) {
     initAES();
 
     // Make sure there is enough space for: IV + plaintext + padding
@@ -60,6 +61,15 @@ std::vector< uint8_t > AesGcmCipher::encrypt( const std::vector< uint8_t >& plai
     // now actually supply key & IV:
     check( EVP_EncryptInit_ex( e_ctx.get(), nullptr, nullptr, key.data(), iv ),
         "Failed to set key/IV" );
+
+    // Process AAD if provided (authenticated but not encrypted)
+    if ( aad.has_value() && !aad->empty() ) {
+        int aad_len = 0;
+        check( EVP_EncryptUpdate( e_ctx.get(), nullptr, &aad_len,
+                   aad->data(), static_cast< int >( aad->size() ) ),
+            "Failed to process AAD" );
+    }
+
     // Cypher data and store in output
     check( EVP_EncryptUpdate( e_ctx.get(), &output[offset], &outlen,
                ( const unsigned char* ) plaintext.data(), plaintext.size() ),
@@ -84,7 +94,8 @@ std::vector< uint8_t > AesGcmCipher::encrypt( const std::vector< uint8_t >& plai
     return std::vector< uint8_t >( output );
 }
 
-std::vector< uint8_t > AesGcmCipher::decrypt( const std::vector< uint8_t >& ciphertext ) {
+std::vector< uint8_t > AesGcmCipher::decrypt( const std::vector< uint8_t >& ciphertext,
+    const std::optional< std::vector< uint8_t > >& aad ) {
     initAES();
 
     constexpr size_t meta = AES_GCM_IV_SIZE + AES_GCM_TAG_SIZE;
@@ -118,6 +129,15 @@ std::vector< uint8_t > AesGcmCipher::decrypt( const std::vector< uint8_t >& ciph
         "Failed to set IV length" );
     check( EVP_DecryptInit_ex( d_ctx.get(), nullptr, nullptr, key.data(), iv ),
         "Failed to set key/IV" );
+
+    // Process AAD if provided (must match what was used during encryption)
+    if ( aad.has_value() && !aad->empty() ) {
+        int aad_len = 0;
+        check( EVP_DecryptUpdate( d_ctx.get(), nullptr, &aad_len,
+                   aad->data(), static_cast< int >( aad->size() ) ),
+            "Failed to process AAD" );
+    }
+
     // Decrypt body
     check( EVP_DecryptUpdate( d_ctx.get(), plaintext.data(), &len, body_ptr, body_len ),
         "Failed to decrypt data" );

--- a/threshold_encryption/AesGcmCipher.h
+++ b/threshold_encryption/AesGcmCipher.h
@@ -30,6 +30,7 @@
 #include <array>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <vector>
 
@@ -68,14 +69,18 @@ public:
     ~AesGcmCipher() = default;
 
     /// @brief Encrypts the given plaintext using AES-256-GCM
-    /// @param plaintext
+    /// @param plaintext The data to encrypt
+    /// @param aad Optional additional authenticated data (not encrypted, but authenticated)
     /// @return Encrypted message
-    std::vector< uint8_t > encrypt( const std::vector< uint8_t >& plaintext );
+    std::vector< uint8_t > encrypt( const std::vector< uint8_t >& plaintext,
+        const std::optional< std::vector< uint8_t > >& aad = std::nullopt );
 
     /// @brief Decrypts the given ciphertext using AES-256-GCM
-    /// @param ciphertext
+    /// @param ciphertext The data to decrypt
+    /// @param aad Optional additional authenticated data (must match what was used during encryption)
     /// @return Decrypted message
-    std::vector< uint8_t > decrypt( const std::vector< uint8_t >& ciphertext );
+    std::vector< uint8_t > decrypt( const std::vector< uint8_t >& ciphertext,
+        const std::optional< std::vector< uint8_t > >& aad = std::nullopt );
 
 private:
     /// Helper function to check if the operation was successful

--- a/threshold_encryption/AesGcmCipher.h
+++ b/threshold_encryption/AesGcmCipher.h
@@ -77,7 +77,8 @@ public:
 
     /// @brief Decrypts the given ciphertext using AES-256-GCM
     /// @param ciphertext The data to decrypt
-    /// @param aad Optional additional authenticated data (must match what was used during encryption)
+    /// @param aad Optional additional authenticated data (must match what was used during
+    /// encryption)
     /// @return Decrypted message
     std::vector< uint8_t > decrypt( const std::vector< uint8_t >& ciphertext,
         const std::optional< std::vector< uint8_t > >& aad = std::nullopt );

--- a/threshold_encryption/ThresholdEncryption.cpp
+++ b/threshold_encryption/ThresholdEncryption.cpp
@@ -102,15 +102,15 @@ std::vector< uint8_t > ThresholdEncryption::mockupDecrypt(
 }
 
 
-Ciphertext ThresholdEncryption::encrypt(
-    const std::vector< uint8_t >& _message, const TEPublicKey& _commonPublic,
+Ciphertext ThresholdEncryption::encrypt( const std::vector< uint8_t >& _message,
+    const TEPublicKey& _commonPublic,
     const std::optional< std::vector< uint8_t > >& _associatedData ) {
     return encrypt( _message, std::vector< TEPublicKey >{ _commonPublic }, _associatedData );
 }
 
 
-Ciphertext ThresholdEncryption::encrypt(
-    const std::vector< uint8_t >& _message, const std::vector< TEPublicKey >& _commonPublic,
+Ciphertext ThresholdEncryption::encrypt( const std::vector< uint8_t >& _message,
+    const std::vector< TEPublicKey >& _commonPublic,
     const std::optional< std::vector< uint8_t > >& _associatedData ) {
     if ( _commonPublic.size() == 0 || _commonPublic.size() > 2 )
         throw ThresholdUtils::IncorrectInput(
@@ -435,9 +435,8 @@ std::vector< bool > ThresholdEncryption::validateCombinedDecryptionBatchParallel
 }
 
 
-std::vector< uint8_t > ThresholdEncryption::decrypt(
-    const Ciphertext& _ciphertext, const AES256Key& _aesKey,
-    const std::optional< std::vector< uint8_t > > _associatedData ) {
+std::vector< uint8_t > ThresholdEncryption::decrypt( const Ciphertext& _ciphertext,
+    const AES256Key& _aesKey, const std::optional< std::vector< uint8_t > > _associatedData ) {
     // decipher & validate plaintext
     std::vector< uint8_t > data = decipherAESAndValidate( _ciphertext, _aesKey, _associatedData );
 
@@ -493,9 +492,8 @@ void ThresholdEncryption::validateDecipheredMessage(
     }
 }
 
-std::vector< uint8_t > ThresholdEncryption::decipherAESAndValidate(
-    const Ciphertext& _ciphertext, const AES256Key& key,
-    const std::optional< std::vector< uint8_t > >& _associatedData ) {
+std::vector< uint8_t > ThresholdEncryption::decipherAESAndValidate( const Ciphertext& _ciphertext,
+    const AES256Key& key, const std::optional< std::vector< uint8_t > >& _associatedData ) {
     AesGcmCipher aesGcmCipher{ key };
     std::vector< uint8_t > data = aesGcmCipher.decrypt( _ciphertext.getData(), _associatedData );
 

--- a/threshold_encryption/ThresholdEncryption.cpp
+++ b/threshold_encryption/ThresholdEncryption.cpp
@@ -103,13 +103,15 @@ std::vector< uint8_t > ThresholdEncryption::mockupDecrypt(
 
 
 Ciphertext ThresholdEncryption::encrypt(
-    const std::vector< uint8_t >& _message, const TEPublicKey& _commonPublic ) {
-    return encrypt( _message, std::vector< TEPublicKey >{ _commonPublic } );
+    const std::vector< uint8_t >& _message, const TEPublicKey& _commonPublic,
+    const std::optional< std::vector< uint8_t > >& _associatedData ) {
+    return encrypt( _message, std::vector< TEPublicKey >{ _commonPublic }, _associatedData );
 }
 
 
 Ciphertext ThresholdEncryption::encrypt(
-    const std::vector< uint8_t >& _message, const std::vector< TEPublicKey >& _commonPublic ) {
+    const std::vector< uint8_t >& _message, const std::vector< TEPublicKey >& _commonPublic,
+    const std::optional< std::vector< uint8_t > >& _associatedData ) {
     if ( _commonPublic.size() == 0 || _commonPublic.size() > 2 )
         throw ThresholdUtils::IncorrectInput(
             "Must provide exactly 1 or 2 public keys for encryption" );
@@ -120,7 +122,7 @@ Ciphertext ThresholdEncryption::encrypt(
         rawPublicKeys.push_back( publicKey.getPublicKeyRaw() );
     }
 
-    CipherResult cipher = TE::encryptWithAES( _message, rawPublicKeys );
+    CipherResult cipher = TE::encryptWithAES( _message, rawPublicKeys, _associatedData );
 
     if ( !cipher.ciphertext ) {
         throw ThresholdUtils::IsNotWellFormed( "ciphertext is null" );
@@ -434,9 +436,10 @@ std::vector< bool > ThresholdEncryption::validateCombinedDecryptionBatchParallel
 
 
 std::vector< uint8_t > ThresholdEncryption::decrypt(
-    const Ciphertext& _ciphertext, const AES256Key& _aesKey ) {
+    const Ciphertext& _ciphertext, const AES256Key& _aesKey,
+    const std::optional< std::vector< uint8_t > > _associatedData ) {
     // decipher & validate plaintext
-    std::vector< uint8_t > data = decipherAESAndValidate( _ciphertext, _aesKey );
+    std::vector< uint8_t > data = decipherAESAndValidate( _ciphertext, _aesKey, _associatedData );
 
     // safe - size of decipheredMessage was already validated
     data.resize( data.size() - RANDOM_SECRET_SIZE_BYTES );
@@ -491,9 +494,10 @@ void ThresholdEncryption::validateDecipheredMessage(
 }
 
 std::vector< uint8_t > ThresholdEncryption::decipherAESAndValidate(
-    const Ciphertext& _ciphertext, const AES256Key& key ) {
+    const Ciphertext& _ciphertext, const AES256Key& key,
+    const std::optional< std::vector< uint8_t > >& _associatedData ) {
     AesGcmCipher aesGcmCipher{ key };
-    std::vector< uint8_t > data = aesGcmCipher.decrypt( _ciphertext.getData() );
+    std::vector< uint8_t > data = aesGcmCipher.decrypt( _ciphertext.getData(), _associatedData );
 
     // validate output
     size_t cipherSize = _ciphertext.getData().size();

--- a/threshold_encryption/ThresholdEncryption.cpp
+++ b/threshold_encryption/ThresholdEncryption.cpp
@@ -46,15 +46,15 @@ std::vector< uint8_t > ThresholdEncryption::mockupEncrypt(
 
     std::copy( key.begin(), key.end(), mockupEncryptedKey.begin() );
 
-    RandSecret random_secret{};  // Zero-initialized
+    RandSecret randomSecret{};  // Zero-initialized
 
     // Append random secret to end of message
-    std::vector< uint8_t > message_to_cipher( _message );
-    message_to_cipher.insert( message_to_cipher.end(), random_secret.begin(), random_secret.end() );
+    std::vector< uint8_t > messageToCipher( _message );
+    messageToCipher.insert( messageToCipher.end(), randomSecret.begin(), randomSecret.end() );
 
     // Cipher message + random secret using AES key
     AesGcmCipher aesGcmCipher{ key };
-    auto encrypted_message = aesGcmCipher.encrypt( message_to_cipher );
+    auto encryptedMessage = aesGcmCipher.encrypt( messageToCipher );
 
     // 0x01 byte is needed for compatibility with real encryption
     // stands for the number of encrypted AES keys in the payload
@@ -63,7 +63,7 @@ std::vector< uint8_t > ThresholdEncryption::mockupEncrypt(
     result.insert( result.end(), mockupEncryptedKey.begin(), mockupEncryptedKey.end() );
 
 #pragma GCC diagnostic ignored "-Wstringop-overread"
-    result.insert( result.end(), encrypted_message.begin(), encrypted_message.end() );
+    result.insert( result.end(), encryptedMessage.begin(), encryptedMessage.end() );
 #pragma GCC diagnostic error "-Wstringop-overread"
 
     return result;
@@ -197,11 +197,11 @@ std::vector< bool > ThresholdEncryption::validateEncryptionBatchParallel(
 
 TEDecryptionShare ThresholdEncryption::partialDecrypt(
     const CipheredKey& _ciphertext, const TEPrivateKeyShare& _pkeyShare ) {
-    algebra::G2Point decryption_share = _pkeyShare.getPrivateKeyRaw() * _ciphertext.U;
+    algebra::G2Point decryptionShare = _pkeyShare.getPrivateKeyRaw() * _ciphertext.U;
     // no need to validate G2Point - if both inputs are already valid, multiplication
     // always produces a valid point
 
-    TEDecryptionShare share( decryption_share, _pkeyShare.getSignerIndex() );
+    TEDecryptionShare share( decryptionShare, _pkeyShare.getSignerIndex() );
 
     return share;
 }
@@ -497,8 +497,8 @@ void ThresholdEncryption::validateDecipheredMessage(
 }
 
 std::vector< uint8_t > ThresholdEncryption::decipherAESAndValidate( const Ciphertext& _ciphertext,
-    const AES256Key& key, const std::optional< std::vector< uint8_t > >& _associatedData ) {
-    AesGcmCipher aesGcmCipher{ key };
+    const AES256Key& _key, const std::optional< std::vector< uint8_t > >& _associatedData ) {
+    AesGcmCipher aesGcmCipher{ _key };
     std::vector< uint8_t > data = aesGcmCipher.decrypt( _ciphertext.getData(), _associatedData );
 
     // validate output

--- a/threshold_encryption/ThresholdEncryption.cpp
+++ b/threshold_encryption/ThresholdEncryption.cpp
@@ -436,7 +436,7 @@ std::vector< bool > ThresholdEncryption::validateCombinedDecryptionBatchParallel
 
 
 std::vector< uint8_t > ThresholdEncryption::decrypt( const Ciphertext& _ciphertext,
-    const AES256Key& _aesKey, const std::optional< std::vector< uint8_t > > _associatedData ) {
+    const AES256Key& _aesKey, const std::optional< std::vector< uint8_t > >& _associatedData ) {
     // decipher & validate plaintext
     std::vector< uint8_t > data = decipherAESAndValidate( _ciphertext, _aesKey, _associatedData );
 

--- a/threshold_encryption/ThresholdEncryption.cpp
+++ b/threshold_encryption/ThresholdEncryption.cpp
@@ -362,10 +362,12 @@ std::vector< std::optional< AES256Key > > ThresholdEncryption::combineSharesBatc
     return result;
 }
 
-void ThresholdEncryption::validateCombinedDecryption(
-    const Ciphertext& _ciphertext, const AES256Key& _aesKey, const TEPublicKey& _publicKey ) {
+void ThresholdEncryption::validateCombinedDecryption( const Ciphertext& _ciphertext,
+    const AES256Key& _aesKey, const TEPublicKey& _publicKey,
+    const std::optional< std::vector< uint8_t > >& _associatedData ) {
     // decipher & validate plaintext
-    std::vector< uint8_t > decipheredMessage = decipherAESAndValidate( _ciphertext, _aesKey );
+    std::vector< uint8_t > decipheredMessage =
+        decipherAESAndValidate( _ciphertext, _aesKey, _associatedData );
 
     validateDecipheredMessage( decipheredMessage, _ciphertext, _aesKey, _publicKey );
 }
@@ -445,10 +447,12 @@ std::vector< uint8_t > ThresholdEncryption::decrypt( const Ciphertext& _cipherte
     return data;
 }
 
-std::vector< uint8_t > ThresholdEncryption::validateAndDecrypt(
-    const Ciphertext& _ciphertext, const AES256Key& _aesKey, const TEPublicKey& _publicKey ) {
+std::vector< uint8_t > ThresholdEncryption::validateAndDecrypt( const Ciphertext& _ciphertext,
+    const AES256Key& _aesKey, const TEPublicKey& _publicKey,
+    const std::optional< std::vector< uint8_t > >& _associatedData ) {
     // decipher & validate plaintext
-    std::vector< uint8_t > decipheredMessage = decipherAESAndValidate( _ciphertext, _aesKey );
+    std::vector< uint8_t > decipheredMessage =
+        decipherAESAndValidate( _ciphertext, _aesKey, _associatedData );
 
     validateDecipheredMessage( decipheredMessage, _ciphertext, _aesKey, _publicKey );
 

--- a/threshold_encryption/ThresholdEncryption.h
+++ b/threshold_encryption/ThresholdEncryption.h
@@ -205,7 +205,7 @@ public:
      * @return std::vector<uint8_t> The decrypted message apart from the random secret
      */
     static std::vector< uint8_t > decrypt( const Ciphertext& _ciphertext, const AES256Key& _aesKey,
-        std::optional< std::vector< uint8_t > > _associatedData = std::nullopt );
+        const std::optional< std::vector< uint8_t > >& _associatedData = std::nullopt );
 
     /**
      * @brief Validates the cyphertext and decrypts the message

--- a/threshold_encryption/ThresholdEncryption.h
+++ b/threshold_encryption/ThresholdEncryption.h
@@ -30,6 +30,7 @@
 #include "threshold_encryption.h"
 #include <tools/utils.h>
 #include <cstddef>
+#include <optional>
 
 namespace libBLS {
 
@@ -57,9 +58,11 @@ public:
      * @return Ciphertext - Struct containing TE(AESKey) and AESKey(message)
      */
     static Ciphertext encrypt(
-        const std::vector< uint8_t >& _message, const TEPublicKey& _commonPublic );
+        const std::vector< uint8_t >& _message, const TEPublicKey& _commonPublic,
+        const std::optional< std::vector< uint8_t > >& _associatedData = std::nullopt );
     static Ciphertext encrypt(
-        const std::vector< uint8_t >& _message, const std::vector< TEPublicKey >& _commonPublic );
+        const std::vector< uint8_t >& _message, const std::vector< TEPublicKey >& _commonPublic,
+        const std::optional< std::vector< uint8_t > >& _associatedData = std::nullopt );
 
     /**
      * @brief Validates the TE ciphered key. SIngle threaded.
@@ -198,10 +201,12 @@ public:
      *
      * @param cyphertext The encrypted message
      * @param aesKey The AES key
+     * @param associatedData The associated data used for encryption
      * @return std::vector<uint8_t> The decrypted message apart from the random secret
      */
     static std::vector< uint8_t > decrypt(
-        const Ciphertext& _ciphertext, const AES256Key& _aesKey );
+        const Ciphertext& _ciphertext, const AES256Key& _aesKey, 
+        std::optional<std::vector< uint8_t >> _associatedData = std::nullopt );
 
     /**
      * @brief Validates the cyphertext and decrypts the message
@@ -248,7 +253,8 @@ private:
      * Helper function
      */
     static std::vector< uint8_t > decipherAESAndValidate(
-        const Ciphertext& _ciphertext, const AES256Key& key );
+        const Ciphertext& _ciphertext, const AES256Key& key,
+        const std::optional< std::vector< uint8_t > >& _associatedData = std::nullopt );
 };
 
 }  // namespace libBLS

--- a/threshold_encryption/ThresholdEncryption.h
+++ b/threshold_encryption/ThresholdEncryption.h
@@ -57,11 +57,11 @@ public:
      * Public key is validated on constructor. Thus it is assumed to be always valid.
      * @return Ciphertext - Struct containing TE(AESKey) and AESKey(message)
      */
-    static Ciphertext encrypt(
-        const std::vector< uint8_t >& _message, const TEPublicKey& _commonPublic,
+    static Ciphertext encrypt( const std::vector< uint8_t >& _message,
+        const TEPublicKey& _commonPublic,
         const std::optional< std::vector< uint8_t > >& _associatedData = std::nullopt );
-    static Ciphertext encrypt(
-        const std::vector< uint8_t >& _message, const std::vector< TEPublicKey >& _commonPublic,
+    static Ciphertext encrypt( const std::vector< uint8_t >& _message,
+        const std::vector< TEPublicKey >& _commonPublic,
         const std::optional< std::vector< uint8_t > >& _associatedData = std::nullopt );
 
     /**
@@ -204,9 +204,8 @@ public:
      * @param associatedData The associated data used for encryption
      * @return std::vector<uint8_t> The decrypted message apart from the random secret
      */
-    static std::vector< uint8_t > decrypt(
-        const Ciphertext& _ciphertext, const AES256Key& _aesKey, 
-        std::optional<std::vector< uint8_t >> _associatedData = std::nullopt );
+    static std::vector< uint8_t > decrypt( const Ciphertext& _ciphertext, const AES256Key& _aesKey,
+        std::optional< std::vector< uint8_t > > _associatedData = std::nullopt );
 
     /**
      * @brief Validates the cyphertext and decrypts the message
@@ -252,8 +251,8 @@ private:
      *
      * Helper function
      */
-    static std::vector< uint8_t > decipherAESAndValidate(
-        const Ciphertext& _ciphertext, const AES256Key& key,
+    static std::vector< uint8_t > decipherAESAndValidate( const Ciphertext& _ciphertext,
+        const AES256Key& key,
         const std::optional< std::vector< uint8_t > >& _associatedData = std::nullopt );
 };
 

--- a/threshold_encryption/ThresholdEncryption.h
+++ b/threshold_encryption/ThresholdEncryption.h
@@ -180,8 +180,9 @@ public:
      * @throws runtime_exception If the decryption using the AES fails (should only happen if the
      * key is tampered)
      */
-    static void validateCombinedDecryption(
-        const Ciphertext& _ciphertext, const AES256Key& _aesKey, const TEPublicKey& _publicKey );
+    static void validateCombinedDecryption( const Ciphertext& _ciphertext, const AES256Key& _aesKey,
+        const TEPublicKey& _publicKey,
+        const std::optional< std::vector< uint8_t > >& _associatedData = std::nullopt );
 
     static std::vector< bool > validateCombinedDecryptionBatch(
         const std::vector< Ciphertext >& _ciphertexts, const std::vector< AES256Key >& _aesKeys,
@@ -212,8 +213,9 @@ public:
      * Same as calling `validateCombinedDecryption` and `decrypt` in sequence,
      * but avoids deciphering twice - more performant alternative
      */
-    static std::vector< uint8_t > validateAndDecrypt(
-        const Ciphertext& _ciphertext, const AES256Key& _aesKey, const TEPublicKey& _publicKey );
+    static std::vector< uint8_t > validateAndDecrypt( const Ciphertext& _ciphertext,
+        const AES256Key& _aesKey, const TEPublicKey& _publicKey,
+        const std::optional< std::vector< uint8_t > >& _associatedData = std::nullopt );
 
     /**
      * @brief validates _aesKey against the one stored in _cyphertext

--- a/threshold_encryption/ThresholdEncryption.h
+++ b/threshold_encryption/ThresholdEncryption.h
@@ -234,9 +234,9 @@ private:
 
     static inline RandSecret extractRandomSecretFromMessage(
         const std::vector< uint8_t >& _message ) {
-        size_t msg_length = _message.size();
+        size_t msgLength = _message.size();
 
-        if ( msg_length < RANDOM_SECRET_SIZE_BYTES ) {
+        if ( msgLength < RANDOM_SECRET_SIZE_BYTES ) {
             throw ThresholdUtils::IncorrectInput( "Message is too short" );
         }
 

--- a/threshold_encryption/encryptMessage.cpp
+++ b/threshold_encryption/encryptMessage.cpp
@@ -27,13 +27,16 @@ along with libBLS. If not, see <https://www.gnu.org/licenses/>.
 
 extern "C" {
 
-const char* encryptMessage( const char* data, const char* key ) {
+const char* encryptMessage( const char* data, const char* key, const char* additionalAuthenticatedData ) {
     static std::string cipheredMessageStr;
 
     libBLS::init();
 
     // convert from char into vec of bytes
     std::vector< uint8_t > messageBytes = libBLS::ThresholdUtils::hexCStringToBytes( data );
+
+    // convert from char into vec of bytes
+    std::vector< uint8_t > additionalAuthenticatedDataBytes = libBLS::ThresholdUtils::hexCStringToBytes( additionalAuthenticatedData );
 
     // build public key
     std::string keyStr( key );
@@ -41,7 +44,7 @@ const char* encryptMessage( const char* data, const char* key ) {
 
     // encrypt message
     libBLS::Ciphertext cipheredMessage =
-        libBLS::ThresholdEncryption::encrypt( messageBytes, commonPublic );
+        libBLS::ThresholdEncryption::encrypt( messageBytes, commonPublic, additionalAuthenticatedDataBytes );
     std::vector< uint8_t > cipheredMessageBytes = cipheredMessage.toBytes();
 
     cipheredMessageStr = libBLS::ThresholdUtils::bytesToHexString( cipheredMessageBytes );
@@ -49,13 +52,16 @@ const char* encryptMessage( const char* data, const char* key ) {
     return cipheredMessageStr.c_str();
 }
 
-const char* encryptMessageDualKey( const char* data, const char* firstKey, const char* secondKey ) {
+const char* encryptMessageDualKey( const char* data, const char* firstKey, const char* secondKey, const char* additionalAuthenticatedData ) {
     static std::string cipheredMessageStr;
 
     libBLS::init();
 
     // convert from char into vec of bytes
     std::vector< uint8_t > messageBytes = libBLS::ThresholdUtils::hexCStringToBytes( data );
+
+    // convert from char into vec of bytes
+    std::vector< uint8_t > additionalAuthenticatedDataBytes = libBLS::ThresholdUtils::hexCStringToBytes( additionalAuthenticatedData );
 
     std::vector< libBLS::TEPublicKey > commonPublicKeys;
     // build public keys
@@ -68,7 +74,7 @@ const char* encryptMessageDualKey( const char* data, const char* firstKey, const
 
     // encrypt message
     libBLS::Ciphertext cipheredMessage =
-        libBLS::ThresholdEncryption::encrypt( messageBytes, commonPublicKeys );
+        libBLS::ThresholdEncryption::encrypt( messageBytes, commonPublicKeys, additionalAuthenticatedDataBytes );
     std::vector< uint8_t > cipheredMessageBytes = cipheredMessage.toBytes();
 
     cipheredMessageStr = libBLS::ThresholdUtils::bytesToHexString( cipheredMessageBytes );

--- a/threshold_encryption/encryptMessage.cpp
+++ b/threshold_encryption/encryptMessage.cpp
@@ -27,7 +27,8 @@ along with libBLS. If not, see <https://www.gnu.org/licenses/>.
 
 extern "C" {
 
-const char* encryptMessage( const char* data, const char* key, const char* additionalAuthenticatedData ) {
+const char* encryptMessage(
+    const char* data, const char* key, const char* additionalAuthenticatedData ) {
     static std::string cipheredMessageStr;
 
     libBLS::init();
@@ -36,15 +37,16 @@ const char* encryptMessage( const char* data, const char* key, const char* addit
     std::vector< uint8_t > messageBytes = libBLS::ThresholdUtils::hexCStringToBytes( data );
 
     // convert from char into vec of bytes
-    std::vector< uint8_t > additionalAuthenticatedDataBytes = libBLS::ThresholdUtils::hexCStringToBytes( additionalAuthenticatedData );
+    std::vector< uint8_t > additionalAuthenticatedDataBytes =
+        libBLS::ThresholdUtils::hexCStringToBytes( additionalAuthenticatedData );
 
     // build public key
     std::string keyStr( key );
     libBLS::TEPublicKey commonPublic( keyStr, libBLS::Base::HEXA );
 
     // encrypt message
-    libBLS::Ciphertext cipheredMessage =
-        libBLS::ThresholdEncryption::encrypt( messageBytes, commonPublic, additionalAuthenticatedDataBytes );
+    libBLS::Ciphertext cipheredMessage = libBLS::ThresholdEncryption::encrypt(
+        messageBytes, commonPublic, additionalAuthenticatedDataBytes );
     std::vector< uint8_t > cipheredMessageBytes = cipheredMessage.toBytes();
 
     cipheredMessageStr = libBLS::ThresholdUtils::bytesToHexString( cipheredMessageBytes );
@@ -52,7 +54,8 @@ const char* encryptMessage( const char* data, const char* key, const char* addit
     return cipheredMessageStr.c_str();
 }
 
-const char* encryptMessageDualKey( const char* data, const char* firstKey, const char* secondKey, const char* additionalAuthenticatedData ) {
+const char* encryptMessageDualKey( const char* data, const char* firstKey, const char* secondKey,
+    const char* additionalAuthenticatedData ) {
     static std::string cipheredMessageStr;
 
     libBLS::init();
@@ -61,7 +64,8 @@ const char* encryptMessageDualKey( const char* data, const char* firstKey, const
     std::vector< uint8_t > messageBytes = libBLS::ThresholdUtils::hexCStringToBytes( data );
 
     // convert from char into vec of bytes
-    std::vector< uint8_t > additionalAuthenticatedDataBytes = libBLS::ThresholdUtils::hexCStringToBytes( additionalAuthenticatedData );
+    std::vector< uint8_t > additionalAuthenticatedDataBytes =
+        libBLS::ThresholdUtils::hexCStringToBytes( additionalAuthenticatedData );
 
     std::vector< libBLS::TEPublicKey > commonPublicKeys;
     // build public keys
@@ -73,8 +77,8 @@ const char* encryptMessageDualKey( const char* data, const char* firstKey, const
     commonPublicKeys.push_back( secondCommonPublic );
 
     // encrypt message
-    libBLS::Ciphertext cipheredMessage =
-        libBLS::ThresholdEncryption::encrypt( messageBytes, commonPublicKeys, additionalAuthenticatedDataBytes );
+    libBLS::Ciphertext cipheredMessage = libBLS::ThresholdEncryption::encrypt(
+        messageBytes, commonPublicKeys, additionalAuthenticatedDataBytes );
     std::vector< uint8_t > cipheredMessageBytes = cipheredMessage.toBytes();
 
     cipheredMessageStr = libBLS::ThresholdUtils::bytesToHexString( cipheredMessageBytes );

--- a/threshold_encryption/threshold_encryption.cpp
+++ b/threshold_encryption/threshold_encryption.cpp
@@ -58,22 +58,22 @@ std::string TE::Hash( const algebra::G2Point& Y ) {
 algebra::G1Point TE::HashToGroup( const algebra::G2Point& U, const AES256Key& V ) {
     // assumed that U lies in G2
 
-    auto U_str = U.toStringArray( Base::DEC );
-    std::string V_str = ThresholdUtils::bytesToHexString( V );
+    auto uStr = U.toStringArray( Base::DEC );
+    std::string vStr = ThresholdUtils::bytesToHexString( V );
 
     // hash 2x
     const std::string sha256hex =
-        ThresholdUtils::sha256( U_str[0] + U_str[1] + U_str[2] + U_str[3] + V_str );
-    std::string hash_str = ThresholdUtils::sha256( sha256hex );
+        ThresholdUtils::sha256( uStr[0] + uStr[1] + uStr[2] + uStr[3] + vStr );
+    std::string hashStr = ThresholdUtils::sha256( sha256hex );
 
-    std::vector< uint8_t > bytes = ThresholdUtils::hexCStringToBytes( hash_str.c_str() );
+    std::vector< uint8_t > bytes = ThresholdUtils::hexCStringToBytes( hashStr.c_str() );
 
     // copy first 32 bytes
-    auto hash_bytes_arr = std::array< uint8_t, algebra::MAX_FIELD_ELEMENT_SIZE_BYTES >();
+    auto hashBytesArr = std::array< uint8_t, algebra::MAX_FIELD_ELEMENT_SIZE_BYTES >();
     std::copy( bytes.begin(), bytes.begin() + algebra::MAX_FIELD_ELEMENT_SIZE_BYTES,
-        hash_bytes_arr.begin() );
+        hashBytesArr.begin() );
 
-    return algebra::G1Point::fromHash( hash_bytes_arr );
+    return algebra::G1Point::fromHash( hashBytesArr );
 }
 
 
@@ -110,7 +110,7 @@ CipheredKeyResult TE::getCiphertext(
             V[i] = key[i] ^ static_cast< uint8_t >( hash[i] );
         }
 
-        std::string v_str = ThresholdUtils::bytesToHexString( V );
+        std::string vStr = ThresholdUtils::bytesToHexString( V );
 
         algebra::G1Point W, H;
 
@@ -120,9 +120,9 @@ CipheredKeyResult TE::getCiphertext(
         cipheredKeys.emplace_back( U, V, W );
     }
 
-    RandSecret random_secret = r.toByteArray();
+    RandSecret randomSecret = r.toByteArray();
 
-    return { cipheredKeys, std::move( random_secret ) };
+    return { cipheredKeys, std::move( randomSecret ) };
 }
 
 /**
@@ -163,18 +163,18 @@ CipherResult TE::encryptWithAES( const std::vector< uint8_t >& message,
     CipheredKeyResult result = getCiphertext( key, commonPublic );
 
     // append random secret to end of message
-    std::vector< uint8_t > message_to_cipher( message );
-    message_to_cipher.insert(
-        message_to_cipher.end(), result.random_secret.begin(), result.random_secret.end() );
+    std::vector< uint8_t > messageToCipher( message );
+    messageToCipher.insert(
+        messageToCipher.end(), result.randomSecret.begin(), result.randomSecret.end() );
 
     // cipher message + random secret using AES key (with optional AAD)
     AesGcmCipher aesGcmCipher{ key };
-    auto encrypted_message = aesGcmCipher.encrypt( message_to_cipher, associatedData );
+    auto encryptedMessage = aesGcmCipher.encrypt( messageToCipher, associatedData );
 
     std::shared_ptr< Ciphertext > ciphertext =
-        std::make_shared< Ciphertext >( result.ciphertext, encrypted_message );
+        std::make_shared< Ciphertext >( result.ciphertext, encryptedMessage );
 
-    return { ciphertext, result.random_secret };
+    return { ciphertext, result.randomSecret };
 }
 
 
@@ -209,7 +209,7 @@ std::pair< std::string, RandSecret > TE::encryptMessage(
     std::vector< uint8_t > ciphertextBytes = ciphertext.ciphertext->toBytes();
 
     std::string ciphertextHexa = ThresholdUtils::bytesToHexString( ciphertextBytes );
-    return std::make_pair( ciphertextHexa, ciphertext.random_secret );
+    return std::make_pair( ciphertextHexa, ciphertext.randomSecret );
 }
 
 
@@ -228,9 +228,9 @@ std::pair< std::string, RandSecret > TE::encryptMessage(
  * @param secret_key The secret key share (element of Fr) used for decryption
  */
 algebra::G2Point TE::getDecryptionShare(
-    const CipheredKey& ciphertext, const algebra::FrScalar& secret_key ) {
-    algebra::G2Point ret_val = secret_key * ciphertext.U;
-    return ret_val;
+    const CipheredKey& ciphertext, const algebra::FrScalar& secretKey ) {
+    algebra::G2Point retVal = secretKey * ciphertext.U;
+    return retVal;
 }
 
 /**
@@ -251,14 +251,14 @@ algebra::G2Point TE::getDecryptionShare(
  * @return false if either the ciphertext is invalid or the decryption share verification fails
  */
 bool TE::Verify( const CipheredKey& ciphertext, const algebra::G2Point& decryptionShare,
-    const algebra::G2Point& public_key ) {
+    const algebra::G2Point& publicKey ) {
     auto [U, V, W] = ciphertext;
 
     algebra::G1Point H = HashToGroup( U, V );
     // no need to validate ciphertext's pairing - assumed to be validated already via
     // `validateEncryption` call
 
-    bool isSecondPairingValid = algebra::verifyPairingEq( W, public_key, H, decryptionShare );
+    bool isSecondPairingValid = algebra::verifyPairingEq( W, publicKey, H, decryptionShare );
     return isSecondPairingValid;
 }
 
@@ -381,11 +381,11 @@ AES256Key TE::CombineSharesIntoAESKey(
         idx[i] = decryptionShares[i].second;
     }
 
-    std::vector< std::reference_wrapper< const algebra::G2Point > > shares_ref;
+    std::vector< std::reference_wrapper< const algebra::G2Point > > sharesRef;
     for ( size_t i = 0; i < this->t_; ++i ) {
-        shares_ref.emplace_back( std::cref( decryptionShares[i].first ) );
+        sharesRef.emplace_back( std::cref( decryptionShares[i].first ) );
     }
-    algebra::G2Point rebuiltG2 = algebra::lagrangeInterpolateAt0( idx, this->t_, shares_ref );
+    algebra::G2Point rebuiltG2 = algebra::lagrangeInterpolateAt0( idx, this->t_, sharesRef );
 
     std::string hash = this->Hash( rebuiltG2 );
 

--- a/threshold_encryption/threshold_encryption.cpp
+++ b/threshold_encryption/threshold_encryption.cpp
@@ -144,14 +144,15 @@ CipheredKeyResult TE::getCiphertext(
  *
  * @note Initializes AES before encryption
  */
-CipherResult TE::encryptWithAES(
-    const std::vector< uint8_t >& message, const algebra::G2Point& commonPublic,
+CipherResult TE::encryptWithAES( const std::vector< uint8_t >& message,
+    const algebra::G2Point& commonPublic,
     const std::optional< std::vector< uint8_t > >& associatedData ) {
-    return encryptWithAES( message, std::vector< algebra::G2Point >{ commonPublic }, associatedData );
+    return encryptWithAES(
+        message, std::vector< algebra::G2Point >{ commonPublic }, associatedData );
 }
 
-CipherResult TE::encryptWithAES(
-    const std::vector< uint8_t >& message, const std::vector< algebra::G2Point >& commonPublic,
+CipherResult TE::encryptWithAES( const std::vector< uint8_t >& message,
+    const std::vector< algebra::G2Point >& commonPublic,
     const std::optional< std::vector< uint8_t > >& associatedData ) {
     // create random AES key
     AES256Key key;

--- a/threshold_encryption/threshold_encryption.cpp
+++ b/threshold_encryption/threshold_encryption.cpp
@@ -145,12 +145,14 @@ CipheredKeyResult TE::getCiphertext(
  * @note Initializes AES before encryption
  */
 CipherResult TE::encryptWithAES(
-    const std::vector< uint8_t >& message, const algebra::G2Point& commonPublic ) {
-    return encryptWithAES( message, std::vector< algebra::G2Point >{ commonPublic } );
+    const std::vector< uint8_t >& message, const algebra::G2Point& commonPublic,
+    const std::optional< std::vector< uint8_t > >& associatedData ) {
+    return encryptWithAES( message, std::vector< algebra::G2Point >{ commonPublic }, associatedData );
 }
 
 CipherResult TE::encryptWithAES(
-    const std::vector< uint8_t >& message, const std::vector< algebra::G2Point >& commonPublic ) {
+    const std::vector< uint8_t >& message, const std::vector< algebra::G2Point >& commonPublic,
+    const std::optional< std::vector< uint8_t > >& associatedData ) {
     // create random AES key
     AES256Key key;
     if ( RAND_bytes( key.data(), key.size() ) != 1 ) {
@@ -164,9 +166,9 @@ CipherResult TE::encryptWithAES(
     message_to_cipher.insert(
         message_to_cipher.end(), result.random_secret.begin(), result.random_secret.end() );
 
-    // cipher message + random secret using AES key
+    // cipher message + random secret using AES key (with optional AAD)
     AesGcmCipher aesGcmCipher{ key };
-    auto encrypted_message = aesGcmCipher.encrypt( message_to_cipher );
+    auto encrypted_message = aesGcmCipher.encrypt( message_to_cipher, associatedData );
 
     std::shared_ptr< Ciphertext > ciphertext =
         std::make_shared< Ciphertext >( result.ciphertext, encrypted_message );

--- a/threshold_encryption/threshold_encryption.h
+++ b/threshold_encryption/threshold_encryption.h
@@ -84,15 +84,15 @@ public:
         std::array< uint8_t, CIPHERED_KEY_SIZE_BYTES > bytes;
         uint8_t* source = bytes.data();
         // set U component
-        auto u_bytes = U.toByteArray();
-        std::memcpy( source, u_bytes.data(), u_bytes.size() );
-        source += u_bytes.size();
+        auto uBytes = U.toByteArray();
+        std::memcpy( source, uBytes.data(), uBytes.size() );
+        source += uBytes.size();
         // set V commponent
         std::memcpy( source, V.data(), V.size() );
         source += V.size();
         // set W component
-        auto w_bytes = W.toByteArray();
-        std::memcpy( source, w_bytes.data(), w_bytes.size() );
+        auto wBytes = W.toByteArray();
+        std::memcpy( source, wBytes.data(), wBytes.size() );
 
         return bytes;
     }
@@ -101,27 +101,27 @@ public:
      * @brief Converts bytes to CipheredKey
      */
     static CipheredKey fromBytes(
-        std::array< uint8_t, CIPHERED_KEY_SIZE_BYTES > bytes, bool _validate = true ) {
-        std::array< uint8_t, G2_SIZE_BYTES > u_bytes;
-        std::array< uint8_t, AES_256_KEY_SIZE_BYTES > v_bytes;
-        std::array< uint8_t, G1_SIZE_BYTES > w_bytes;
+        std::array< uint8_t, CIPHERED_KEY_SIZE_BYTES > _bytes, bool _validate = true ) {
+        std::array< uint8_t, G2_SIZE_BYTES > uBytes;
+        std::array< uint8_t, AES_256_KEY_SIZE_BYTES > vBytes;
+        std::array< uint8_t, G1_SIZE_BYTES > wBytes;
 
-        uint8_t* offset = bytes.data();
+        uint8_t* offset = _bytes.data();
         // Get U bytes
-        std::memcpy( u_bytes.data(), offset, G2_SIZE_BYTES );
+        std::memcpy( uBytes.data(), offset, G2_SIZE_BYTES );
         offset += G2_SIZE_BYTES;
         // Get V bytes
-        std::memcpy( v_bytes.data(), offset, AES_256_KEY_SIZE_BYTES );
+        std::memcpy( vBytes.data(), offset, AES_256_KEY_SIZE_BYTES );
         offset += AES_256_KEY_SIZE_BYTES;
         // Get W bytes
-        std::memcpy( w_bytes.data(), offset, G1_SIZE_BYTES );
+        std::memcpy( wBytes.data(), offset, G1_SIZE_BYTES );
 
         // Convert to CipheredKey components
-        algebra::G2Point U = algebra::G2Point::fromBytes( u_bytes );
-        algebra::G1Point W = algebra::G1Point::fromBytes( w_bytes );
+        algebra::G2Point U = algebra::G2Point::fromBytes( uBytes );
+        algebra::G1Point W = algebra::G1Point::fromBytes( wBytes );
 
         // constructor performs validation
-        return CipheredKey( U, v_bytes, W, _validate );
+        return CipheredKey( U, vBytes, W, _validate );
     }
 
     /**
@@ -163,8 +163,8 @@ public:
         std::vector< std::string > res;
         res.reserve( keys.size() );
         for ( const auto& U : U_points ) {
-            auto u_splitted = U.toString( Base::HEXA );
-            res.push_back( u_splitted );
+            auto uSplitted = U.toString( Base::HEXA );
+            res.push_back( uSplitted );
         }
 
         return res;
@@ -362,16 +362,16 @@ public:
 /**
  * @brief The result of the encryption process
  * Only accessible by the party that cyphers the text.
- * `random_secret` should never be shared.
+ * `randomSecret` should never be shared.
  */
 struct CipherResult {
     std::shared_ptr< Ciphertext > ciphertext;
-    RandSecret random_secret;
+    RandSecret randomSecret;
 };
 
 struct CipheredKeyResult {
     std::vector< CipheredKey > ciphertext;
-    RandSecret random_secret;
+    RandSecret randomSecret;
 };
 
 class TE {
@@ -417,14 +417,14 @@ public:
         const std::vector< uint8_t >& message, const std::vector< std::string >& commonPublic );
 
     static algebra::G2Point getDecryptionShare(
-        const CipheredKey& ciphertext, const algebra::FrScalar& secret_key );
+        const CipheredKey& ciphertext, const algebra::FrScalar& secretKey );
 
     static algebra::G1Point HashToGroup( const algebra::G2Point& U, const AES256Key& V );
 
     static std::string Hash( const algebra::G2Point& Y );
 
     static bool Verify( const CipheredKey& ciphertext, const algebra::G2Point& decryptionShare,
-        const algebra::G2Point& public_key );
+        const algebra::G2Point& publicKey );
 
     static std::vector< bool > VerifyBatch( const std::vector< CipheredKey >& ciphertexts,
         const std::vector< algebra::G2Point >& decryptionShares,

--- a/threshold_encryption/threshold_encryption.h
+++ b/threshold_encryption/threshold_encryption.h
@@ -25,6 +25,7 @@ along with libBLS. If not, see <https://www.gnu.org/licenses/>.
 
 #include <openssl/rand.h>
 #include <array>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -404,9 +405,11 @@ public:
         const AES256Key& key, const std::vector< algebra::G2Point >& commonPublic );
 
     static CipherResult encryptWithAES(
-        const std::vector< uint8_t >& message, const algebra::G2Point& commonPublic );
+        const std::vector< uint8_t >& message, const algebra::G2Point& commonPublic,
+        const std::optional< std::vector< uint8_t > >& associatedData = std::nullopt );
     static CipherResult encryptWithAES( const std::vector< uint8_t >& message,
-        const std::vector< algebra::G2Point >& commonPublic );
+        const std::vector< algebra::G2Point >& commonPublic,
+        const std::optional< std::vector< uint8_t > >& associatedData = std::nullopt );
 
     static std::pair< std::string, RandSecret > encryptMessage(
         const std::vector< uint8_t >& message, const std::string& commonPublic );

--- a/threshold_encryption/threshold_encryption.h
+++ b/threshold_encryption/threshold_encryption.h
@@ -404,8 +404,8 @@ public:
     static CipheredKeyResult getCiphertext(
         const AES256Key& key, const std::vector< algebra::G2Point >& commonPublic );
 
-    static CipherResult encryptWithAES(
-        const std::vector< uint8_t >& message, const algebra::G2Point& commonPublic,
+    static CipherResult encryptWithAES( const std::vector< uint8_t >& message,
+        const algebra::G2Point& commonPublic,
         const std::optional< std::vector< uint8_t > >& associatedData = std::nullopt );
     static CipherResult encryptWithAES( const std::vector< uint8_t >& message,
         const std::vector< algebra::G2Point >& commonPublic,

--- a/tools/utils.cpp
+++ b/tools/utils.cpp
@@ -191,7 +191,17 @@ std::string ThresholdUtils::bytesToHexString( const std::vector< uint8_t >& byte
 }
 
 std::vector< uint8_t > ThresholdUtils::hexCStringToBytes( const char* hexStr ) {
+    if ( hexStr == nullptr ) {
+        throw IncorrectInput( "Hex string is null." );
+    }
+
     size_t len = validateHexCString( hexStr );
+
+    // Limit to 2MB hex string (1MB of decoded data)
+    constexpr size_t MAX_HEX_STRING_LENGTH = 1024 * 1024 * 2;
+    if ( len > MAX_HEX_STRING_LENGTH ) {
+        throw IncorrectInput( "Hex string exceeds maximum allowed length." );
+    }
 
     std::vector< uint8_t > bytes( len / 2 );
 


### PR DESCRIPTION
## Description

Allows optional AAD field to tie encryption process to some specific context

Fixed core dump issue when running tests:
- The default entrypoint (start.sh) runs `check_firewall.py` before starting sgxwallet - uses Tor to verify that sgxwallet ports aren't exposed to the internet.
- However, Tor connectivity is blocked in GitHub Actions, causing the script to hang indefinitely.
- **Workaround:** Use a custom entrypoint that skips check_firewall.py and starts sgxwallet directly.

## Tests
Added tests for the new functionality & to ensure backward compatibility with previous version (without AAD).

## Performance
No changes for code that uses version without AAD.

Fixes #276 