### PR TITLE
Add AAD for TE

### DIFF
--- a/test/test_TE_wrappers.cpp
+++ b/test/test_TE_wrappers.cpp
@@ -86,12 +86,16 @@ BOOST_AUTO_TEST_CASE( TEEncryptDecryptWithAAD ) {
 
     std::vector< uint8_t > message = randomByteVec( 100 );
 
-    // AAD that binds the ciphertext to a specific context (e.g., contract address)
-    std::vector< uint8_t > aad = { 0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE };
+    // Separate AADs for AES and TE with different values
+    std::vector< uint8_t > aadAES = { 0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE };
+    std::vector< uint8_t > aadTE = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
 
-    // Encrypt with AAD
+    // Encrypt with both AADs
+    libBLS::ThresholdEncryption::EncryptMetaData metaData;
+    metaData.associatedDataAesCbc = aadAES;
+    metaData.assocaitedDataTE = aadTE;
     libBLS::Ciphertext cypher =
-        libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic, aad );
+        libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic, metaData );
 
     std::vector< libBLS::TEPublicKeyShare > public_key_shares;
     for ( size_t i = 0; i < numAll; i++ ) {
@@ -99,23 +103,24 @@ BOOST_AUTO_TEST_CASE( TEEncryptDecryptWithAAD ) {
     }
 
     for ( const auto& cipheredKey : cypher.getKeys() ) {
-        libBLS::ThresholdEncryption::validateEncryption( cipheredKey );
+        // Validate with TE AAD
+        libBLS::ThresholdEncryption::validateEncryption( cipheredKey, &aadTE );
 
         libBLS::TEDecryptSet decrSet( numSigned, numAll );
         for ( size_t i = 0; i < numSigned; i++ ) {
             libBLS::TEDecryptionShare decr_share =
                 libBLS::ThresholdEncryption::partialDecrypt( cipheredKey, keys.secretKeys[i] );
             libBLS::ThresholdEncryption::validateDecryptionShare(
-                cipheredKey, decr_share, public_key_shares[i] );
+                cipheredKey, decr_share, public_key_shares[i], &aadTE );
             decrSet.addDecryptShare( decr_share );
         }
 
         libBLS::AES256Key key_decrypted =
             libBLS::ThresholdEncryption::combineShares( cipheredKey, decrSet );
 
-        // Decrypt WITH the same AAD - should succeed
+        // Decrypt WITH the same AES AAD - should succeed
         std::vector< uint8_t > decipheredMsg =
-            libBLS::ThresholdEncryption::decrypt( cypher, key_decrypted, aad );
+            libBLS::ThresholdEncryption::decrypt( cypher, key_decrypted, aadAES );
         BOOST_REQUIRE( decipheredMsg == message );
     }
 }
@@ -129,14 +134,19 @@ BOOST_AUTO_TEST_CASE( TEEncryptDecryptWithWrongAAD ) {
 
     std::vector< uint8_t > message = randomByteVec( 100 );
 
-    // AAD used for encryption
-    std::vector< uint8_t > aad = { 0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE };
-    // Wrong AAD for decryption
-    std::vector< uint8_t > wrong_aad = { 0x01, 0x02, 0x03, 0x04 };
+    // AADs used for encryption
+    std::vector< uint8_t > aadAES = { 0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE };
+    std::vector< uint8_t > aadTE = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+    // Wrong AADs for decryption/validation
+    std::vector< uint8_t > wrong_aadAES = { 0x11, 0x22, 0x33, 0x44 };
+    std::vector< uint8_t > wrong_aadTE = { 0xAA, 0xBB, 0xCC, 0xDD };
 
-    // Encrypt with AAD
+    // Encrypt with both AADs
+    libBLS::ThresholdEncryption::EncryptMetaData metaData;
+    metaData.associatedDataAesCbc = aadAES;
+    metaData.assocaitedDataTE = aadTE;
     libBLS::Ciphertext cypher =
-        libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic, aad );
+        libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic, metaData );
 
     std::vector< libBLS::TEPublicKeyShare > public_key_shares;
     for ( size_t i = 0; i < numAll; i++ ) {
@@ -144,6 +154,14 @@ BOOST_AUTO_TEST_CASE( TEEncryptDecryptWithWrongAAD ) {
     }
 
     for ( const auto& cipheredKey : cypher.getKeys() ) {
+        // Validate with wrong TE AAD - should fail
+        BOOST_REQUIRE_THROW(
+            libBLS::ThresholdEncryption::validateEncryption( cipheredKey, &wrong_aadTE ),
+            libBLS::ThresholdUtils::IsNotWellFormed );
+
+        // Validate with correct TE AAD - should succeed
+        libBLS::ThresholdEncryption::validateEncryption( cipheredKey, &aadTE );
+
         libBLS::TEDecryptSet decrSet( numSigned, numAll );
         for ( size_t i = 0; i < numSigned; i++ ) {
             libBLS::TEDecryptionShare decr_share =
@@ -154,12 +172,12 @@ BOOST_AUTO_TEST_CASE( TEEncryptDecryptWithWrongAAD ) {
         libBLS::AES256Key key_decrypted =
             libBLS::ThresholdEncryption::combineShares( cipheredKey, decrSet );
 
-        // Decrypt with wrong AAD - should fail
+        // Decrypt with wrong AES AAD - should fail
         BOOST_REQUIRE_THROW(
-            libBLS::ThresholdEncryption::decrypt( cypher, key_decrypted, wrong_aad ),
+            libBLS::ThresholdEncryption::decrypt( cypher, key_decrypted, wrong_aadAES ),
             std::runtime_error );
 
-        // Decrypt without AAD - should also fail
+        // Decrypt without AES AAD - should also fail
         BOOST_REQUIRE_THROW(
             libBLS::ThresholdEncryption::decrypt( cypher, key_decrypted, std::nullopt ),
             std::runtime_error );

--- a/test/test_TE_wrappers.cpp
+++ b/test/test_TE_wrappers.cpp
@@ -214,15 +214,13 @@ BOOST_AUTO_TEST_CASE( TEValidateDecryptionShareWithWrongAAD ) {
             cipheredKey, decr_share, public_key_shares[0], &aadTE );
 
         // Validate with wrong TE AAD - should fail
-        BOOST_REQUIRE_THROW(
-            libBLS::ThresholdEncryption::validateDecryptionShare(
-                cipheredKey, decr_share, public_key_shares[0], &wrong_aadTE ),
+        BOOST_REQUIRE_THROW( libBLS::ThresholdEncryption::validateDecryptionShare(
+                                 cipheredKey, decr_share, public_key_shares[0], &wrong_aadTE ),
             libBLS::ThresholdUtils::IsNotWellFormed );
 
         // Validate with nullptr AAD on AAD-encrypted ciphertext - should fail
-        BOOST_REQUIRE_THROW(
-            libBLS::ThresholdEncryption::validateDecryptionShare(
-                cipheredKey, decr_share, public_key_shares[0], nullptr ),
+        BOOST_REQUIRE_THROW( libBLS::ThresholdEncryption::validateDecryptionShare(
+                                 cipheredKey, decr_share, public_key_shares[0], nullptr ),
             libBLS::ThresholdUtils::IsNotWellFormed );
     }
 }
@@ -376,7 +374,8 @@ BOOST_AUTO_TEST_CASE( TEValidateWithoutAADOnAADEncrypted ) {
 
     for ( const auto& cipheredKey : cypher.getKeys() ) {
         // Validate without TE AAD (nullptr) - should fail
-        BOOST_REQUIRE_THROW( libBLS::ThresholdEncryption::validateEncryption( cipheredKey, nullptr ),
+        BOOST_REQUIRE_THROW(
+            libBLS::ThresholdEncryption::validateEncryption( cipheredKey, nullptr ),
             libBLS::ThresholdUtils::IsNotWellFormed );
 
         // Validate with correct TE AAD - should succeed
@@ -423,7 +422,8 @@ BOOST_AUTO_TEST_CASE( TEBatchValidationWithAAD ) {
     }
 
     // Batch validate with wrong AADs - all should fail
-    auto wrongResults = libBLS::ThresholdEncryption::validateEncryptionBatch( cipheredKeys, &wrongAadVec );
+    auto wrongResults =
+        libBLS::ThresholdEncryption::validateEncryptionBatch( cipheredKeys, &wrongAadVec );
     BOOST_REQUIRE( wrongResults.size() == batchSize );
     for ( size_t i = 0; i < batchSize; ++i ) {
         BOOST_REQUIRE( wrongResults[i] == false );
@@ -432,7 +432,6 @@ BOOST_AUTO_TEST_CASE( TEBatchValidationWithAAD ) {
 
 
 BOOST_AUTO_TEST_CASE( TEProcessWithWrappers ) {
-
     for ( size_t i = 0; i < 10; i++ ) {
         size_t numAll = rand_gen() % 16 + 1;
         size_t numSigned = rand_gen() % numAll + 1;

--- a/test/test_TE_wrappers.cpp
+++ b/test/test_TE_wrappers.cpp
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE( TEEncryptDecryptWithAAD ) {
     // Encrypt with both AADs
     libBLS::ThresholdEncryption::EncryptMetaData metaData;
     metaData.associatedDataAesCbc = aadAES;
-    metaData.assocaitedDataTE = aadTE;
+    metaData.associatedDataTE = aadTE;
     libBLS::Ciphertext cypher =
         libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic, metaData );
 
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE( TEEncryptDecryptWithWrongAAD ) {
     // Encrypt with both AADs
     libBLS::ThresholdEncryption::EncryptMetaData metaData;
     metaData.associatedDataAesCbc = aadAES;
-    metaData.assocaitedDataTE = aadTE;
+    metaData.associatedDataTE = aadTE;
     libBLS::Ciphertext cypher =
         libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic, metaData );
 

--- a/test/test_TE_wrappers.cpp
+++ b/test/test_TE_wrappers.cpp
@@ -184,7 +184,255 @@ BOOST_AUTO_TEST_CASE( TEEncryptDecryptWithWrongAAD ) {
     }
 }
 
+BOOST_AUTO_TEST_CASE( TEValidateDecryptionShareWithWrongAAD ) {
+    // Test that validateDecryptionShare fails with wrong TE AAD
+    size_t numAll = 4;
+    size_t numSigned = 3;
+
+    keys keys = generateKeys( numSigned, numAll );
+    std::vector< uint8_t > message = randomByteVec( 100 );
+
+    std::vector< uint8_t > aadTE = { 0x01, 0x02, 0x03, 0x04 };
+    std::vector< uint8_t > wrong_aadTE = { 0xAA, 0xBB, 0xCC, 0xDD };
+
+    libBLS::ThresholdEncryption::EncryptMetaData metaData;
+    metaData.associatedDataTE = aadTE;
+    libBLS::Ciphertext cypher =
+        libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic, metaData );
+
+    std::vector< libBLS::TEPublicKeyShare > public_key_shares;
+    for ( size_t i = 0; i < numAll; i++ ) {
+        public_key_shares.emplace_back( libBLS::TEPublicKeyShare( keys.secretKeys[i] ) );
+    }
+
+    for ( const auto& cipheredKey : cypher.getKeys() ) {
+        libBLS::TEDecryptionShare decr_share =
+            libBLS::ThresholdEncryption::partialDecrypt( cipheredKey, keys.secretKeys[0] );
+
+        // Validate with correct TE AAD - should succeed
+        libBLS::ThresholdEncryption::validateDecryptionShare(
+            cipheredKey, decr_share, public_key_shares[0], &aadTE );
+
+        // Validate with wrong TE AAD - should fail
+        BOOST_REQUIRE_THROW(
+            libBLS::ThresholdEncryption::validateDecryptionShare(
+                cipheredKey, decr_share, public_key_shares[0], &wrong_aadTE ),
+            libBLS::ThresholdUtils::IsNotWellFormed );
+
+        // Validate with nullptr AAD on AAD-encrypted ciphertext - should fail
+        BOOST_REQUIRE_THROW(
+            libBLS::ThresholdEncryption::validateDecryptionShare(
+                cipheredKey, decr_share, public_key_shares[0], nullptr ),
+            libBLS::ThresholdUtils::IsNotWellFormed );
+    }
+}
+
+BOOST_AUTO_TEST_CASE( TEEncryptWithTEAADOnly ) {
+    // Test encryption with only TE AAD (no AES AAD)
+    size_t numAll = 4;
+    size_t numSigned = 3;
+
+    keys keys = generateKeys( numSigned, numAll );
+    std::vector< uint8_t > message = randomByteVec( 100 );
+
+    std::vector< uint8_t > aadTE = { 0x01, 0x02, 0x03, 0x04 };
+
+    libBLS::ThresholdEncryption::EncryptMetaData metaData;
+    metaData.associatedDataTE = aadTE;  // Only TE AAD, no AES AAD
+
+    libBLS::Ciphertext cypher =
+        libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic, metaData );
+
+    std::vector< libBLS::TEPublicKeyShare > public_key_shares;
+    for ( size_t i = 0; i < numAll; i++ ) {
+        public_key_shares.emplace_back( libBLS::TEPublicKeyShare( keys.secretKeys[i] ) );
+    }
+
+    for ( const auto& cipheredKey : cypher.getKeys() ) {
+        // Validate encryption with TE AAD
+        libBLS::ThresholdEncryption::validateEncryption( cipheredKey, &aadTE );
+
+        libBLS::TEDecryptSet decrSet( numSigned, numAll );
+        for ( size_t i = 0; i < numSigned; i++ ) {
+            libBLS::TEDecryptionShare decr_share =
+                libBLS::ThresholdEncryption::partialDecrypt( cipheredKey, keys.secretKeys[i] );
+            libBLS::ThresholdEncryption::validateDecryptionShare(
+                cipheredKey, decr_share, public_key_shares[i], &aadTE );
+            decrSet.addDecryptShare( decr_share );
+        }
+
+        libBLS::AES256Key key_decrypted =
+            libBLS::ThresholdEncryption::combineShares( cipheredKey, decrSet );
+
+        // Decrypt without AES AAD - should succeed since no AES AAD was used
+        std::vector< uint8_t > decipheredMsg =
+            libBLS::ThresholdEncryption::decrypt( cypher, key_decrypted, std::nullopt );
+        BOOST_REQUIRE( decipheredMsg == message );
+    }
+}
+
+BOOST_AUTO_TEST_CASE( TEEncryptWithAESAADOnly ) {
+    // Test encryption with only AES AAD (no TE AAD)
+    size_t numAll = 4;
+    size_t numSigned = 3;
+
+    keys keys = generateKeys( numSigned, numAll );
+    std::vector< uint8_t > message = randomByteVec( 100 );
+
+    std::vector< uint8_t > aadAES = { 0xDE, 0xAD, 0xBE, 0xEF };
+
+    libBLS::ThresholdEncryption::EncryptMetaData metaData;
+    metaData.associatedDataAesCbc = aadAES;  // Only AES AAD, no TE AAD
+
+    libBLS::Ciphertext cypher =
+        libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic, metaData );
+
+    std::vector< libBLS::TEPublicKeyShare > public_key_shares;
+    for ( size_t i = 0; i < numAll; i++ ) {
+        public_key_shares.emplace_back( libBLS::TEPublicKeyShare( keys.secretKeys[i] ) );
+    }
+
+    for ( const auto& cipheredKey : cypher.getKeys() ) {
+        // Validate encryption without TE AAD - should succeed
+        libBLS::ThresholdEncryption::validateEncryption( cipheredKey, nullptr );
+
+        libBLS::TEDecryptSet decrSet( numSigned, numAll );
+        for ( size_t i = 0; i < numSigned; i++ ) {
+            libBLS::TEDecryptionShare decr_share =
+                libBLS::ThresholdEncryption::partialDecrypt( cipheredKey, keys.secretKeys[i] );
+            libBLS::ThresholdEncryption::validateDecryptionShare(
+                cipheredKey, decr_share, public_key_shares[i], nullptr );
+            decrSet.addDecryptShare( decr_share );
+        }
+
+        libBLS::AES256Key key_decrypted =
+            libBLS::ThresholdEncryption::combineShares( cipheredKey, decrSet );
+
+        // Decrypt with AES AAD - should succeed
+        std::vector< uint8_t > decipheredMsg =
+            libBLS::ThresholdEncryption::decrypt( cypher, key_decrypted, aadAES );
+        BOOST_REQUIRE( decipheredMsg == message );
+    }
+}
+
+BOOST_AUTO_TEST_CASE( TEEncryptWithEmptyAAD ) {
+    size_t numAll = 4;
+    size_t numSigned = 3;
+
+    keys keys = generateKeys( numSigned, numAll );
+    std::vector< uint8_t > message = randomByteVec( 100 );
+
+    // Empty AAD vectors
+    std::vector< uint8_t > emptyAadAES = {};
+    std::vector< uint8_t > emptyAadTE = {};
+
+    libBLS::ThresholdEncryption::EncryptMetaData metaData;
+    metaData.associatedDataAesCbc = emptyAadAES;
+    metaData.associatedDataTE = emptyAadTE;
+
+    libBLS::Ciphertext cypher =
+        libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic, metaData );
+
+    std::vector< libBLS::TEPublicKeyShare > public_key_shares;
+    for ( size_t i = 0; i < numAll; i++ ) {
+        public_key_shares.emplace_back( libBLS::TEPublicKeyShare( keys.secretKeys[i] ) );
+    }
+
+    for ( const auto& cipheredKey : cypher.getKeys() ) {
+        // Validate with empty TE AAD
+        libBLS::ThresholdEncryption::validateEncryption( cipheredKey, &emptyAadTE );
+
+        libBLS::TEDecryptSet decrSet( numSigned, numAll );
+        for ( size_t i = 0; i < numSigned; i++ ) {
+            libBLS::TEDecryptionShare decr_share =
+                libBLS::ThresholdEncryption::partialDecrypt( cipheredKey, keys.secretKeys[i] );
+            decrSet.addDecryptShare( decr_share );
+        }
+
+        libBLS::AES256Key key_decrypted =
+            libBLS::ThresholdEncryption::combineShares( cipheredKey, decrSet );
+
+        // Decrypt with empty AES AAD
+        std::vector< uint8_t > decipheredMsg =
+            libBLS::ThresholdEncryption::decrypt( cypher, key_decrypted, emptyAadAES );
+        BOOST_REQUIRE( decipheredMsg == message );
+    }
+}
+
+BOOST_AUTO_TEST_CASE( TEValidateWithoutAADOnAADEncrypted ) {
+    size_t numAll = 4;
+    size_t numSigned = 3;
+
+    keys keys = generateKeys( numSigned, numAll );
+    std::vector< uint8_t > message = randomByteVec( 100 );
+
+    std::vector< uint8_t > aadTE = { 0x01, 0x02, 0x03, 0x04 };
+
+    libBLS::ThresholdEncryption::EncryptMetaData metaData;
+    metaData.associatedDataTE = aadTE;
+
+    libBLS::Ciphertext cypher =
+        libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic, metaData );
+
+    for ( const auto& cipheredKey : cypher.getKeys() ) {
+        // Validate without TE AAD (nullptr) - should fail
+        BOOST_REQUIRE_THROW( libBLS::ThresholdEncryption::validateEncryption( cipheredKey, nullptr ),
+            libBLS::ThresholdUtils::IsNotWellFormed );
+
+        // Validate with correct TE AAD - should succeed
+        libBLS::ThresholdEncryption::validateEncryption( cipheredKey, &aadTE );
+    }
+}
+
+BOOST_AUTO_TEST_CASE( TEBatchValidationWithAAD ) {
+    // Test batch validation with AAD
+    size_t numAll = 4;
+    size_t numSigned = 3;
+
+    keys keys = generateKeys( numSigned, numAll );
+    std::vector< uint8_t > message = randomByteVec( 100 );
+
+    // Create multiple ciphertexts with AAD
+    size_t batchSize = 5;
+    std::vector< libBLS::CipheredKey > cipheredKeys;
+    std::vector< std::vector< uint8_t > > aadVec;
+
+    for ( size_t i = 0; i < batchSize; ++i ) {
+        std::vector< uint8_t > aadTE = { 0x01, 0x02, 0x03, static_cast< uint8_t >( i ) };
+        aadVec.push_back( aadTE );
+
+        libBLS::ThresholdEncryption::EncryptMetaData metaData;
+        metaData.associatedDataTE = aadTE;
+
+        libBLS::Ciphertext cypher =
+            libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic, metaData );
+        cipheredKeys.push_back( cypher.getKeys()[0] );
+    }
+
+    // Batch validate with correct AADs - all should pass
+    auto results = libBLS::ThresholdEncryption::validateEncryptionBatch( cipheredKeys, &aadVec );
+    BOOST_REQUIRE( results.size() == batchSize );
+    for ( size_t i = 0; i < batchSize; ++i ) {
+        BOOST_REQUIRE( results[i] == true );
+    }
+
+    // Create wrong AADs
+    std::vector< std::vector< uint8_t > > wrongAadVec;
+    for ( size_t i = 0; i < batchSize; ++i ) {
+        wrongAadVec.push_back( { 0xFF, 0xFE, 0xFD, static_cast< uint8_t >( i ) } );
+    }
+
+    // Batch validate with wrong AADs - all should fail
+    auto wrongResults = libBLS::ThresholdEncryption::validateEncryptionBatch( cipheredKeys, &wrongAadVec );
+    BOOST_REQUIRE( wrongResults.size() == batchSize );
+    for ( size_t i = 0; i < batchSize; ++i ) {
+        BOOST_REQUIRE( wrongResults[i] == false );
+    }
+}
+
+
 BOOST_AUTO_TEST_CASE( TEProcessWithWrappers ) {
+
     for ( size_t i = 0; i < 10; i++ ) {
         size_t numAll = rand_gen() % 16 + 1;
         size_t numSigned = rand_gen() % numAll + 1;

--- a/test/test_encrypt_message.cpp
+++ b/test/test_encrypt_message.cpp
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
         libBLS::TEPublicKey publicKey( pKeyStr, libBLS::Base::HEXA );
         libBLS::ThresholdEncryption::EncryptMetaData metaData;
         metaData.associatedDataAesCbc = additionalAuthenticatedData;
-        metaData.assocaitedDataTE = additionalAuthenticatedDataTE;
+        metaData.associatedDataTE = additionalAuthenticatedDataTE;
 
         libBLS::Ciphertext ciphertext =
             libBLS::ThresholdEncryption::encrypt( data, publicKey, metaData );
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
         }
         libBLS::ThresholdEncryption::EncryptMetaData metaData;
         metaData.associatedDataAesCbc = additionalAuthenticatedData;
-        metaData.assocaitedDataTE = additionalAuthenticatedDataTE;
+        metaData.associatedDataTE = additionalAuthenticatedDataTE;
         libBLS::Ciphertext ciphertext =
             libBLS::ThresholdEncryption::encrypt( data, commonPublicKeys, metaData );
         std::vector< uint8_t > cipheredMessageBytesTarget = ciphertext.toBytes();

--- a/test/test_encrypt_message.cpp
+++ b/test/test_encrypt_message.cpp
@@ -63,28 +63,38 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
         std::string str = libBLS::ThresholdUtils::bytesToHexString( data );
         const char* dataStr = str.c_str();
 
-        std::vector< uint8_t > additionalAuthenticatedData = { 'a', 'd', 'd', 'i', 't', 'i', 'o',
-            'n', 'a', 'l', 'A', 'u', 't', 'h', 'e', 'n', 't', 'i', 'c', 'a', 't', 'e', 'd', 'D',
-            'a', 't', 'a' };
+        std::vector< uint8_t > additionalAuthenticatedData = { 'A', 'E', 'S' };
+        std::vector< uint8_t > additionalAuthenticatedDataTE = { 'T', 'E' };
         std::string additionalAuthenticatedDataStr =
             libBLS::ThresholdUtils::bytesToHexString( additionalAuthenticatedData );
         const char* additionalAuthenticatedDataStrC = additionalAuthenticatedDataStr.c_str();
 
+        std::string additionalAuthenticatedDataTEStr =
+            libBLS::ThresholdUtils::bytesToHexString( additionalAuthenticatedDataTE );
+        const char* additionalAuthenticatedDataTEStrC = additionalAuthenticatedDataTEStr.c_str();
+
         // call encrypt message
-        const char* cipheredMessage =
-            encryptMessage( dataStr, pKeyStr.c_str(), additionalAuthenticatedDataStrC );
+        const char* cipheredMessage = encryptMessage( dataStr, pKeyStr.c_str(),
+            additionalAuthenticatedDataStrC, additionalAuthenticatedDataTEStrC );
         std::vector< uint8_t > cipheredMessageBytesActual =
             libBLS::ThresholdUtils::hexCStringToBytes( cipheredMessage );
 
         // encrypt message using libBLS
         libBLS::TEPublicKey publicKey( pKeyStr, libBLS::Base::HEXA );
+        libBLS::ThresholdEncryption::EncryptMetaData metaData;
+        metaData.associatedDataAesCbc = additionalAuthenticatedData;
+        metaData.assocaitedDataTE = additionalAuthenticatedDataTE;
+
         libBLS::Ciphertext ciphertext =
-            libBLS::ThresholdEncryption::encrypt( data, publicKey, additionalAuthenticatedData );
+            libBLS::ThresholdEncryption::encrypt( data, publicKey, metaData );
         std::vector< uint8_t > cipheredMessageBytesTarget = ciphertext.toBytes();
 
         // cannot compare their contents since each has a different random secret, which results
         // in different ciphered messages - just check their lengths
         BOOST_REQUIRE( cipheredMessageBytesActual.size() == cipheredMessageBytesTarget.size() );
+
+        libBLS::ThresholdEncryption::validateEncryption(
+            ciphertext.keys[0], &additionalAuthenticatedDataTE );
 
         // run TE process over the ciphered message from JS
         libBLS::Ciphertext cipheredMessageObj =
@@ -134,16 +144,19 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
             publicKeysStr[j] = pKeyStr;
         }
 
-        std::vector< uint8_t > additionalAuthenticatedData = { 'a', 'd', 'd', 'i', 't', 'i', 'o',
-            'n', 'a', 'l', 'A', 'u', 't', 'h', 'e', 'n', 't', 'i', 'c', 'a', 't', 'e', 'd', 'D',
-            'a', 't', 'a' };
+        std::vector< uint8_t > additionalAuthenticatedData = { 'A', 'E', 'S' };
+        std::vector< uint8_t > additionalAuthenticatedDataTE = { 'T', 'E' };
         std::string additionalAuthenticatedDataStr =
             libBLS::ThresholdUtils::bytesToHexString( additionalAuthenticatedData );
         const char* additionalAuthenticatedDataStrC = additionalAuthenticatedDataStr.c_str();
+        std::string additionalAuthenticatedDataTEStr =
+            libBLS::ThresholdUtils::bytesToHexString( additionalAuthenticatedDataTE );
+        const char* additionalAuthenticatedDataTEStrC = additionalAuthenticatedDataTEStr.c_str();
 
         // call encrypt message
-        const char* cipheredMessage = encryptMessageDualKey( dataStr, publicKeysStr[0].c_str(),
-            publicKeysStr[1].c_str(), additionalAuthenticatedDataStrC );
+        const char* cipheredMessage =
+            encryptMessageDualKey( dataStr, publicKeysStr[0].c_str(), publicKeysStr[1].c_str(),
+                additionalAuthenticatedDataStrC, additionalAuthenticatedDataTEStrC );
         std::vector< uint8_t > cipheredMessageBytesActual =
             libBLS::ThresholdUtils::hexCStringToBytes( cipheredMessage );
 
@@ -152,8 +165,11 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
         for ( const auto& publicKey : publicKeysStr ) {
             commonPublicKeys.push_back( libBLS::TEPublicKey( publicKey, libBLS::Base::HEXA ) );
         }
-        libBLS::Ciphertext ciphertext = libBLS::ThresholdEncryption::encrypt(
-            data, commonPublicKeys, additionalAuthenticatedData );
+        libBLS::ThresholdEncryption::EncryptMetaData metaData;
+        metaData.associatedDataAesCbc = additionalAuthenticatedData;
+        metaData.assocaitedDataTE = additionalAuthenticatedDataTE;
+        libBLS::Ciphertext ciphertext =
+            libBLS::ThresholdEncryption::encrypt( data, commonPublicKeys, metaData );
         std::vector< uint8_t > cipheredMessageBytesTarget = ciphertext.toBytes();
 
         // cannot compare their contents since each has a different random secret, which results

--- a/threshold_encryption/CMakeLists.txt
+++ b/threshold_encryption/CMakeLists.txt
@@ -19,6 +19,8 @@ set(SOURCES
     TEPublicKeyShare.cpp
     ThresholdEncryption.cpp
     AesGcmCipher.cpp
+    CipheredKey.cpp
+    Ciphertext.cpp
 )
 
 set(HEADERS
@@ -33,6 +35,8 @@ set(HEADERS
     TEPublicKeyShare.h
     ThresholdEncryption.h
     AesGcmCipher.h
+    CipheredKey.h
+    Ciphertext.h
 )
 
 set(PROJECT_VERSION 0.2.0)

--- a/threshold_encryption/CipheredKey.cpp
+++ b/threshold_encryption/CipheredKey.cpp
@@ -1,9 +1,9 @@
 #include <array>
 #include <vector>
 
-#include "backends/algebra.hpp"
 #include "AesGcmCipher.h"
 #include "CipheredKey.h"
+#include "backends/algebra.hpp"
 
 namespace libBLS {
 
@@ -90,6 +90,4 @@ std::vector< std::string > CipheredKey::getDecryptionShareInputBatch(
 }
 
 
-
-
-}
+}  // namespace libBLS

--- a/threshold_encryption/CipheredKey.cpp
+++ b/threshold_encryption/CipheredKey.cpp
@@ -1,0 +1,95 @@
+#include <array>
+#include <vector>
+
+#include "backends/algebra.hpp"
+#include "AesGcmCipher.h"
+#include "CipheredKey.h"
+
+namespace libBLS {
+
+
+std::array< uint8_t, CipheredKey::CIPHERED_KEY_SIZE_BYTES > CipheredKey::toBytes() const {
+    std::array< uint8_t, CIPHERED_KEY_SIZE_BYTES > bytes;
+    uint8_t* source = bytes.data();
+    // set U component
+    auto uBytes = U.toByteArray();
+    std::memcpy( source, uBytes.data(), uBytes.size() );
+    source += uBytes.size();
+    // set V commponent
+    std::memcpy( source, V.data(), V.size() );
+    source += V.size();
+    // set W component
+    auto wBytes = W.toByteArray();
+    std::memcpy( source, wBytes.data(), wBytes.size() );
+
+    return bytes;
+}
+
+
+CipheredKey CipheredKey::fromBytes(
+    std::array< uint8_t, CIPHERED_KEY_SIZE_BYTES > _bytes, bool _validate ) {
+    std::array< uint8_t, G2_SIZE_BYTES > uBytes;
+    std::array< uint8_t, AES_256_KEY_SIZE_BYTES > vBytes;
+    std::array< uint8_t, G1_SIZE_BYTES > wBytes;
+
+    uint8_t* offset = _bytes.data();
+    // Get U bytes
+    std::memcpy( uBytes.data(), offset, G2_SIZE_BYTES );
+    offset += G2_SIZE_BYTES;
+    // Get V bytes
+    std::memcpy( vBytes.data(), offset, AES_256_KEY_SIZE_BYTES );
+    offset += AES_256_KEY_SIZE_BYTES;
+    // Get W bytes
+    std::memcpy( wBytes.data(), offset, G1_SIZE_BYTES );
+
+    // Convert to CipheredKey components
+    algebra::G2Point U = algebra::G2Point::fromBytes( uBytes );
+    algebra::G1Point W = algebra::G1Point::fromBytes( wBytes );
+
+    // constructor performs validation
+    return CipheredKey( U, vBytes, W, _validate );
+}
+
+void CipheredKey::validate() const {
+    W.validate();
+    U.validate();
+}
+
+CipheredKey CipheredKey::random() {
+    algebra::G2Point U = algebra::G2Point::random();
+    AES256Key V;
+    RAND_bytes( V.data(), V.size() );
+    algebra::G1Point W = algebra::G1Point::random();
+    return CipheredKey( U, V, W );
+}
+
+std::string CipheredKey::getDecryptionShareInput() {
+    U.toAffineCoordinates();
+    return U.toString( Base::HEXA );
+}
+
+std::vector< std::string > CipheredKey::getDecryptionShareInputBatch(
+    const std::vector< CipheredKey >& keys ) {
+    std::vector< algebra::G2Point > U_points;
+    U_points.reserve( keys.size() );
+    for ( const auto& key : keys ) {
+        U_points.push_back( key.U );
+    }
+
+    // batch convert all to affine coordinates
+    toAffineVec( U_points );
+
+    std::vector< std::string > res;
+    res.reserve( keys.size() );
+    for ( const auto& U : U_points ) {
+        auto uSplitted = U.toString( Base::HEXA );
+        res.push_back( uSplitted );
+    }
+
+    return res;
+}
+
+
+
+
+}

--- a/threshold_encryption/CipheredKey.h
+++ b/threshold_encryption/CipheredKey.h
@@ -3,8 +3,8 @@
 #include <array>
 #include <vector>
 
-#include "backends/algebra.hpp"
 #include "AesGcmCipher.h"
+#include "backends/algebra.hpp"
 
 namespace libBLS {
 
@@ -69,4 +69,4 @@ public:
     const algebra::G1Point& getW() const { return W; }
 };
 
-} // namespace libBLS
+}  // namespace libBLS

--- a/threshold_encryption/CipheredKey.h
+++ b/threshold_encryption/CipheredKey.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <array>
+#include <vector>
+
+#include "backends/algebra.hpp"
+#include "AesGcmCipher.h"
+
+namespace libBLS {
+
+/**
+ * @brief Holds the AES key ciphered via
+ * Threshold Encryption
+ */
+struct CipheredKey {
+    static constexpr size_t CIPHERED_KEY_SIZE_BYTES =
+        algebra::G2Point::SIZE_BYTES + AES_256_KEY_SIZE_BYTES + algebra::G1Point::SIZE_BYTES;
+
+    algebra::G2Point U;
+    AES256Key V;
+    algebra::G1Point W;
+
+public:
+    CipheredKey() = default;
+    CipheredKey( algebra::G2Point _U, AES256Key _V, algebra::G1Point _W, bool _validate = true )
+        : U( _U ), V( std::move( _V ) ), W( _W ) {
+        if ( _validate )
+            validate();
+    }
+
+    bool operator==( const CipheredKey& other ) const {
+        return ( U == other.U ) && ( V == other.V ) && ( W == other.W );
+    }
+
+    /**
+     * @brief Converts CipheredKey to bytes
+     * The byte format returned is: `[ U | V | W ]`
+     * where `U` and `W` are elements of G2 and G1 groups respectively,
+     * and `V` is a fixed size AES256Key.
+     *
+     * Final byte representation is always of fixed size.
+     */
+    std::array< uint8_t, CIPHERED_KEY_SIZE_BYTES > toBytes() const;
+
+    /**
+     * @brief Converts bytes to CipheredKey
+     */
+    static CipheredKey fromBytes(
+        std::array< uint8_t, CIPHERED_KEY_SIZE_BYTES > _bytes, bool _validate = true );
+
+    /**
+     * @brief Validates the CipheredKey
+     * @throw NotWellFormed if the key is not well formed
+     */
+    void validate() const;
+
+    static CipheredKey random();
+
+    /**
+     * Converts U component of the key to string
+     */
+    std::string getDecryptionShareInput();
+
+    static std::vector< std::string > getDecryptionShareInputBatch(
+        const std::vector< CipheredKey >& keys );
+
+    const algebra::G2Point& getU() const { return U; }
+    const AES256Key& getV() const { return V; }
+    const algebra::G1Point& getW() const { return W; }
+};
+
+} // namespace libBLS

--- a/threshold_encryption/Ciphertext.cpp
+++ b/threshold_encryption/Ciphertext.cpp
@@ -17,8 +17,8 @@ const std::vector< uint8_t > Ciphertext::toBytes() const {
 
     // Calculate total size needed
     size_t totalSize = sizeof( uint8_t ) +  // for number of keys
-                        ( keys.size() * CipheredKey::CIPHERED_KEY_SIZE_BYTES ) +  // for all keys
-                        data->size();                                             // for data
+                       ( keys.size() * CipheredKey::CIPHERED_KEY_SIZE_BYTES ) +  // for all keys
+                       data->size();                                             // for data
 
     std::vector< uint8_t > bytes;
     bytes.reserve( totalSize );
@@ -43,7 +43,7 @@ const std::vector< uint8_t > Ciphertext::toBytes() const {
 Ciphertext Ciphertext::fromBytes( std::vector< uint8_t >& bytes, bool _validate ) {
     // we require at least 1 byte for num_keys + one key + random secret + 1 byte for data
     if ( bytes.size() <=
-            sizeof( uint8_t ) + CipheredKey::CIPHERED_KEY_SIZE_BYTES + RANDOM_SECRET_SIZE_BYTES ) {
+         sizeof( uint8_t ) + CipheredKey::CIPHERED_KEY_SIZE_BYTES + RANDOM_SECRET_SIZE_BYTES ) {
         throw ThresholdUtils::IncorrectInput( "Cyphertext data is too short" );
     }
 
@@ -58,9 +58,9 @@ Ciphertext Ciphertext::fromBytes( std::vector< uint8_t >& bytes, bool _validate 
         throw ThresholdUtils::IncorrectInput( "Ciphertext must contain exactly 1 or 2 keys" );
 
     // Check that the input matches the number of keys
-    size_t expectedMinSize =
-        sizeof( uint8_t ) + ( numKeys * CipheredKey::CIPHERED_KEY_SIZE_BYTES ) +
-        RANDOM_SECRET_SIZE_BYTES + 1;  // +1 for at least 1 byte of actual data
+    size_t expectedMinSize = sizeof( uint8_t ) +
+                             ( numKeys * CipheredKey::CIPHERED_KEY_SIZE_BYTES ) +
+                             RANDOM_SECRET_SIZE_BYTES + 1;  // +1 for at least 1 byte of actual data
     if ( bytes.size() < expectedMinSize )
         throw ThresholdUtils::IncorrectInput(
             "Cyphertext data is too short for specified number of keys" );
@@ -71,8 +71,7 @@ Ciphertext Ciphertext::fromBytes( std::vector< uint8_t >& bytes, bool _validate 
 
     for ( size_t i = 0; i < numKeys; ++i ) {
         std::array< uint8_t, CipheredKey::CIPHERED_KEY_SIZE_BYTES > keyBytes;
-        std::memcpy(
-            keyBytes.data(), bytes.data() + offset, CipheredKey::CIPHERED_KEY_SIZE_BYTES );
+        std::memcpy( keyBytes.data(), bytes.data() + offset, CipheredKey::CIPHERED_KEY_SIZE_BYTES );
         offset += CipheredKey::CIPHERED_KEY_SIZE_BYTES;
 
         // do not validate CipheredKey here
@@ -106,7 +105,9 @@ void Ciphertext::validate() const {
     }
 }
 
-const std::vector< CipheredKey >& Ciphertext::getKeys() const { return keys; }
+const std::vector< CipheredKey >& Ciphertext::getKeys() const {
+    return keys;
+}
 
 void Ciphertext::keepKey( size_t _idx ) {
     if ( _idx >= keys.size() || keys.size() != 2 )
@@ -121,4 +122,4 @@ const CipheredKey& Ciphertext::getTargetKey() const {
     return keys.front();
 }
 
-}
+}  // namespace libBLS

--- a/threshold_encryption/Ciphertext.cpp
+++ b/threshold_encryption/Ciphertext.cpp
@@ -1,0 +1,124 @@
+#include "Ciphertext.h"
+
+namespace libBLS {
+
+const std::vector< uint8_t >& Ciphertext::getData() const {
+    if ( !data ) {
+        throw ThresholdUtils::IncorrectInput( "Cyphertext data is not initialized" );
+    }
+    return *data;
+}
+
+
+const std::vector< uint8_t > Ciphertext::toBytes() const {
+    if ( !data ) {
+        throw ThresholdUtils::IncorrectInput( "Cyphertext data is not initialized" );
+    }
+
+    // Calculate total size needed
+    size_t totalSize = sizeof( uint8_t ) +  // for number of keys
+                        ( keys.size() * CipheredKey::CIPHERED_KEY_SIZE_BYTES ) +  // for all keys
+                        data->size();                                             // for data
+
+    std::vector< uint8_t > bytes;
+    bytes.reserve( totalSize );
+
+    // Add number of keys
+    uint8_t numKeys = static_cast< uint8_t >( keys.size() );
+    bytes.push_back( numKeys );
+
+    // Add each key
+    for ( const auto& key : keys ) {
+        std::array< uint8_t, CipheredKey::CIPHERED_KEY_SIZE_BYTES > keyBytes = key.toBytes();
+        bytes.insert( bytes.end(), keyBytes.begin(), keyBytes.end() );
+    }
+
+    // Add data
+    bytes.insert( bytes.end(), data->begin(), data->end() );
+
+    return bytes;
+}
+
+
+Ciphertext Ciphertext::fromBytes( std::vector< uint8_t >& bytes, bool _validate ) {
+    // we require at least 1 byte for num_keys + one key + random secret + 1 byte for data
+    if ( bytes.size() <=
+            sizeof( uint8_t ) + CipheredKey::CIPHERED_KEY_SIZE_BYTES + RANDOM_SECRET_SIZE_BYTES ) {
+        throw ThresholdUtils::IncorrectInput( "Cyphertext data is too short" );
+    }
+
+    size_t offset = 0;
+
+    // Get number of keys
+    uint8_t numKeys;
+    std::memcpy( &numKeys, bytes.data() + offset, sizeof( uint8_t ) );
+    offset += sizeof( uint8_t );
+
+    if ( numKeys == 0 || numKeys > 2 )
+        throw ThresholdUtils::IncorrectInput( "Ciphertext must contain exactly 1 or 2 keys" );
+
+    // Check that the input matches the number of keys
+    size_t expectedMinSize =
+        sizeof( uint8_t ) + ( numKeys * CipheredKey::CIPHERED_KEY_SIZE_BYTES ) +
+        RANDOM_SECRET_SIZE_BYTES + 1;  // +1 for at least 1 byte of actual data
+    if ( bytes.size() < expectedMinSize )
+        throw ThresholdUtils::IncorrectInput(
+            "Cyphertext data is too short for specified number of keys" );
+
+    // Extract keys
+    std::vector< CipheredKey > keys;
+    keys.reserve( numKeys );
+
+    for ( size_t i = 0; i < numKeys; ++i ) {
+        std::array< uint8_t, CipheredKey::CIPHERED_KEY_SIZE_BYTES > keyBytes;
+        std::memcpy(
+            keyBytes.data(), bytes.data() + offset, CipheredKey::CIPHERED_KEY_SIZE_BYTES );
+        offset += CipheredKey::CIPHERED_KEY_SIZE_BYTES;
+
+        // do not validate CipheredKey here
+        // if validation is enabled, CipheredKey is validated in Ciphertext's constructor
+        // otherwise we don't need validation at all
+        keys.push_back( CipheredKey::fromBytes( keyBytes, false ) );
+    }
+
+    // Get data bytes
+    std::vector< uint8_t > data( bytes.begin() + offset, bytes.end() );
+
+    return Ciphertext( keys, data, _validate );
+}
+
+void Ciphertext::validate() const {
+    if ( keys.empty() || keys.size() > 2 )
+        throw ThresholdUtils::IsNotWellFormed( "Ciphertext must contain exactly 1 or 2 keys" );
+
+    for ( const auto& key : keys ) {
+        key.validate();
+    }
+
+    if ( !data ) {
+        throw ThresholdUtils::IsNotWellFormed( "Cyphertext data is not initialized" );
+    }
+
+    // actual data without random secret must be at least 1 byte long
+    if ( data->size() <= RANDOM_SECRET_SIZE_BYTES ) {
+        throw ThresholdUtils::IsNotWellFormed(
+            "Cyphertext data is too short to hold random secret and at least 1 byte of data." );
+    }
+}
+
+const std::vector< CipheredKey >& Ciphertext::getKeys() const { return keys; }
+
+void Ciphertext::keepKey( size_t _idx ) {
+    if ( _idx >= keys.size() || keys.size() != 2 )
+        throw ThresholdUtils::IncorrectInput(
+            "Key index is greater than number of the keys in ciphertext" );
+    keys.erase( keys.begin() + ( keys.size() - _idx - 1 ) );
+}
+
+const CipheredKey& Ciphertext::getTargetKey() const {
+    if ( keys.size() != 1 )
+        throw ThresholdUtils::IncorrectInput( "Cannot choose a target key" );
+    return keys.front();
+}
+
+}

--- a/threshold_encryption/Ciphertext.h
+++ b/threshold_encryption/Ciphertext.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <vector>
 #include <memory>
+#include <vector>
 
 #include <tools/utils.h>
 
@@ -93,4 +93,3 @@ public:
 };
 
 }  // namespace libBLS
-

--- a/threshold_encryption/Ciphertext.h
+++ b/threshold_encryption/Ciphertext.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <vector>
+#include <memory>
+
+#include <tools/utils.h>
+
+#include "CipheredKey.h"
+
+namespace libBLS {
+
+constexpr size_t RANDOM_SECRET_SIZE_BYTES = MAX_FIELD_ELEMENT_SIZE_BYTES;
+
+/**
+ * @brief Holds the ciphered AES keys (vector), as well as the data
+ * ciphered with AES key.
+ */
+struct Ciphertext {
+    std::vector< CipheredKey > keys;
+    std::shared_ptr< std::vector< uint8_t > > data;
+
+public:
+    bool operator==( const Ciphertext& other ) const {
+        bool baseParams = keys == other.keys;
+        if ( data && other.data ) {
+            return baseParams && ( *data == *other.data );
+        }
+        return baseParams;
+    }
+
+    Ciphertext() = default;
+
+    Ciphertext( const std::vector< CipheredKey >& _keys, const std::vector< uint8_t >& _data,
+        bool _validate = true )
+        : keys( _keys ), data( std::make_shared< std::vector< uint8_t > >( _data ) ) {
+        if ( _validate )
+            validate();
+    }
+
+    Ciphertext(
+        const CipheredKey& _key, const std::vector< uint8_t >& _data, bool _validate = true )
+        : keys( { _key } ), data( std::make_shared< std::vector< uint8_t > >( _data ) ) {
+        if ( _validate )
+            validate();
+    }
+
+    // Constructor for exactly two keys
+    Ciphertext( const CipheredKey& _key1, const CipheredKey& _key2,
+        const std::vector< uint8_t >& _data, bool _validate = true )
+        : keys( { _key1, _key2 } ), data( std::make_shared< std::vector< uint8_t > >( _data ) ) {
+        if ( _validate )
+            validate();
+    }
+
+    const std::vector< uint8_t >& getData() const;
+
+    /**
+     * @brief Converts Ciphertext to bytes
+     * The byte format returned is: `[ num_keys | key1 | key2 | ... | data ]`
+     *
+     * where `data` can be of arbitrary size, each `key` is a fixed size,
+     * and `num_keys` is a 1-byte integer indicating the number of keys.
+     */
+    const std::vector< uint8_t > toBytes() const;
+
+    /**
+     * @brief Converts bytes to Ciphertext
+     */
+    static Ciphertext fromBytes( std::vector< uint8_t >& bytes, bool _validate = true );
+
+    /**
+     * @brief Validates the Ciphertext
+     * @throw NotWellFormed if the it fails the validation
+     */
+    void validate() const;
+
+    /**
+     * @brief Returns the vector of keys in the Ciphertext
+     */
+    const std::vector< CipheredKey >& getKeys() const;
+
+    /**
+     * @brief keeps only one key for validation and decryption
+     * @param idx - index of the key to keep
+     */
+    void keepKey( size_t _idx );
+
+    /**
+     * @brief get a CipheredKey for validation and decryption
+     * @throw IncorrectInput if there are 0 or 2 keys to choose
+     */
+    const CipheredKey& getTargetKey() const;
+};
+
+}  // namespace libBLS
+

--- a/threshold_encryption/ThresholdEncryption.cpp
+++ b/threshold_encryption/ThresholdEncryption.cpp
@@ -103,15 +103,13 @@ std::vector< uint8_t > ThresholdEncryption::mockupDecrypt(
 
 
 Ciphertext ThresholdEncryption::encrypt( const std::vector< uint8_t >& _message,
-    const TEPublicKey& _commonPublic,
-    const std::optional< std::vector< uint8_t > >& _associatedData ) {
-    return encrypt( _message, std::vector< TEPublicKey >{ _commonPublic }, _associatedData );
+    const TEPublicKey& _commonPublic, const EncryptMetaData& _metaData ) {
+    return encrypt( _message, std::vector< TEPublicKey >{ _commonPublic }, _metaData );
 }
 
 
 Ciphertext ThresholdEncryption::encrypt( const std::vector< uint8_t >& _message,
-    const std::vector< TEPublicKey >& _commonPublic,
-    const std::optional< std::vector< uint8_t > >& _associatedData ) {
+    const std::vector< TEPublicKey >& _commonPublic, const EncryptMetaData& _metaData ) {
     if ( _commonPublic.size() == 0 || _commonPublic.size() > 2 )
         throw ThresholdUtils::IncorrectInput(
             "Must provide exactly 1 or 2 public keys for encryption" );
@@ -122,7 +120,8 @@ Ciphertext ThresholdEncryption::encrypt( const std::vector< uint8_t >& _message,
         rawPublicKeys.push_back( publicKey.getPublicKeyRaw() );
     }
 
-    CipherResult cipher = TE::encryptWithAES( _message, rawPublicKeys, _associatedData );
+    CipherResult cipher = TE::encryptWithAES(
+        _message, rawPublicKeys, _metaData.associatedDataAesCbc, _metaData.assocaitedDataTE );
 
     if ( !cipher.ciphertext ) {
         throw ThresholdUtils::IsNotWellFormed( "ciphertext is null" );
@@ -133,10 +132,11 @@ Ciphertext ThresholdEncryption::encrypt( const std::vector< uint8_t >& _message,
     return *cipher.ciphertext;
 }
 
-void ThresholdEncryption::validateEncryption( const CipheredKey& _ciphertext ) {
+void ThresholdEncryption::validateEncryption(
+    const CipheredKey& _ciphertext, const std::vector< uint8_t >* _associatedDataTE ) {
     const auto& [U, V, W] = _ciphertext;
 
-    algebra::G1Point H = TE::HashToGroup( U, V );
+    algebra::G1Point H = TE::HashToGroup( U, V, _associatedDataTE );
 
     // pairing( W, P ) == pairing( H, U )
     bool validPairing = algebra::verifyPairingEq( W, algebra::G2Point::generator(), H, U );
@@ -147,9 +147,14 @@ void ThresholdEncryption::validateEncryption( const CipheredKey& _ciphertext ) {
 }
 
 std::vector< bool > ThresholdEncryption::validateEncryptionBatch(
-    const std::vector< CipheredKey >& _ciphertexts ) {
+    const std::vector< CipheredKey >& _ciphertexts,
+    const std::vector< std::vector< uint8_t > >* _associatedDataTE ) {
     if ( _ciphertexts.empty() ) {
         return {};
+    }
+
+    if ( _associatedDataTE && _associatedDataTE->size() != _ciphertexts.size() ) {
+        throw ThresholdUtils::IncorrectInput( "Associated data TE size does not match" );
     }
 
     // Store concrete values (no reference_wrapper)
@@ -167,7 +172,9 @@ std::vector< bool > ThresholdEncryption::validateEncryptionBatch(
 
     for ( size_t i = 0; i < size; ++i ) {
         const auto& [U, V, W] = _ciphertexts.at( i );
-        const algebra::G1Point H = TE::HashToGroup( U, V );
+        const std::vector< uint8_t >* aadPtr =
+            _associatedDataTE ? &_associatedDataTE->at( i ) : nullptr;
+        const algebra::G1Point H = TE::HashToGroup( U, V, aadPtr );
 
         g1P1s.at( i ) = W;
         g1P2s.at( i ) = H;
@@ -180,16 +187,29 @@ std::vector< bool > ThresholdEncryption::validateEncryptionBatch(
 }
 
 std::vector< bool > ThresholdEncryption::validateEncryptionBatchParallel(
-    const std::vector< CipheredKey >& _ciphertexts ) {
+    const std::vector< CipheredKey >& _ciphertexts,
+    const std::vector< std::vector< uint8_t > >* _associatedDataTE ) {
     if ( _ciphertexts.empty() ) {
         return {};
     }
 
+    if ( _associatedDataTE && _associatedDataTE->size() != _ciphertexts.size() ) {
+        throw ThresholdUtils::IncorrectInput( "Associated data TE size does not match" );
+    }
+
     auto result = ThresholdUtils::executeInParallel< bool >(
-        _ciphertexts.size(), [&_ciphertexts]( size_t startIdx, size_t endIdx ) {
+        _ciphertexts.size(), [&_ciphertexts, _associatedDataTE]( size_t startIdx, size_t endIdx ) {
             const std::vector< CipheredKey > subset(
                 _ciphertexts.begin() + startIdx, _ciphertexts.begin() + endIdx );
-            return ThresholdEncryption::validateEncryptionBatch( subset );
+            // Slice AAD vector for this subset
+            const std::vector< std::vector< uint8_t > >* aadSubset = nullptr;
+            std::vector< std::vector< uint8_t > > aadSubsetStorage;
+            if ( _associatedDataTE ) {
+                aadSubsetStorage.assign(
+                    _associatedDataTE->begin() + startIdx, _associatedDataTE->begin() + endIdx );
+                aadSubset = &aadSubsetStorage;
+            }
+            return ThresholdEncryption::validateEncryptionBatch( subset, aadSubset );
         } );
 
     return result;
@@ -207,9 +227,10 @@ TEDecryptionShare ThresholdEncryption::partialDecrypt(
 }
 
 void ThresholdEncryption::validateDecryptionShare( const CipheredKey& _cipherText,
-    const TEDecryptionShare& _decryptionShare, const TEPublicKeyShare& _publicKey ) {
-    if ( !TE::Verify(
-             _cipherText, _decryptionShare.getShareRaw(), _publicKey.getPublicKeyRaw() ) ) {
+    const TEDecryptionShare& _decryptionShare, const TEPublicKeyShare& _publicKey,
+    const std::vector< uint8_t >* _associatedDataTE ) {
+    if ( !TE::Verify( _cipherText, _decryptionShare.getShareRaw(), _publicKey.getPublicKeyRaw(),
+             _associatedDataTE ) ) {
         throw ThresholdUtils::IsNotWellFormed( "Invalid decryption share" );
     }
 }
@@ -217,7 +238,8 @@ void ThresholdEncryption::validateDecryptionShare( const CipheredKey& _cipherTex
 std::vector< bool > ThresholdEncryption::validateDecryptionSharesBatch(
     const std::vector< CipheredKey >& _cipherTexts,
     const std::vector< TEDecryptionShare >& _decryptionShares,
-    const std::vector< TEPublicKeyShare >& _publicKeys ) {
+    const std::vector< TEPublicKeyShare >& _publicKeys,
+    const std::vector< std::vector< uint8_t > >* _associatedDataTE ) {
     if ( _cipherTexts.empty() ) {
         return {};
     }
@@ -233,13 +255,14 @@ std::vector< bool > ThresholdEncryption::validateDecryptionSharesBatch(
         publicKeysRaw.push_back( key.getPublicKeyRaw() );
     }
 
-    return TE::VerifyBatch( _cipherTexts, decryptionSharesRaw, publicKeysRaw );
+    return TE::VerifyBatch( _cipherTexts, decryptionSharesRaw, publicKeysRaw, _associatedDataTE );
 }
 
 std::vector< bool > ThresholdEncryption::validateDecryptionSharesBatchParallel(
     const std::vector< CipheredKey >& _cipherTexts,
     const std::vector< TEDecryptionShare >& _decryptionShares,
-    const std::vector< TEPublicKeyShare >& _publicKeys ) {
+    const std::vector< TEPublicKeyShare >& _publicKeys,
+    const std::vector< std::vector< uint8_t > >* _associatedDataTE ) {
     if ( _cipherTexts.empty() ) {
         return {};
     }
@@ -257,11 +280,16 @@ std::vector< bool > ThresholdEncryption::validateDecryptionSharesBatchParallel(
             "Decryption shares size must be multiple of ciphertexts size" );
     }
 
+    if ( _associatedDataTE && _associatedDataTE->size() != _cipherTexts.size() ) {
+        throw ThresholdUtils::IncorrectInput(
+            "Associated data size must match number of ciphertexts" );
+    }
+
     size_t sharesPerCiphertext = _decryptionShares.size() / _cipherTexts.size();
 
-    auto result = libBLS::ThresholdUtils::executeInParallel< bool >(
-        _cipherTexts.size(), [sharesPerCiphertext, &_cipherTexts, &_decryptionShares, &_publicKeys](
-                                 size_t startIdx, size_t endIdx ) {
+    auto result = libBLS::ThresholdUtils::executeInParallel< bool >( _cipherTexts.size(),
+        [sharesPerCiphertext, &_cipherTexts, &_decryptionShares, &_publicKeys, _associatedDataTE](
+            size_t startIdx, size_t endIdx ) {
             const std::vector< CipheredKey > ciphertexts(
                 _cipherTexts.begin() + startIdx, _cipherTexts.begin() + endIdx );
             const std::vector< TEDecryptionShare > decryptionShares(
@@ -271,8 +299,17 @@ std::vector< bool > ThresholdEncryption::validateDecryptionSharesBatchParallel(
                 _publicKeys.begin() + startIdx * sharesPerCiphertext,
                 _publicKeys.begin() + endIdx * sharesPerCiphertext );
 
+            // Slice AAD for this subset
+            const std::vector< std::vector< uint8_t > >* aadSubset = nullptr;
+            std::vector< std::vector< uint8_t > > aadSubsetStorage;
+            if ( _associatedDataTE ) {
+                aadSubsetStorage.assign(
+                    _associatedDataTE->begin() + startIdx, _associatedDataTE->begin() + endIdx );
+                aadSubset = &aadSubsetStorage;
+            }
+
             return ThresholdEncryption::validateDecryptionSharesBatch(
-                ciphertexts, decryptionShares, publicKeys );
+                ciphertexts, decryptionShares, publicKeys, aadSubset );
         } );
     return result;
 }

--- a/threshold_encryption/ThresholdEncryption.cpp
+++ b/threshold_encryption/ThresholdEncryption.cpp
@@ -121,7 +121,7 @@ Ciphertext ThresholdEncryption::encrypt( const std::vector< uint8_t >& _message,
     }
 
     CipherResult cipher = TE::encryptWithAES(
-        _message, rawPublicKeys, _metaData.associatedDataAesCbc, _metaData.assocaitedDataTE );
+        _message, rawPublicKeys, _metaData.associatedDataAesCbc, _metaData.associatedDataTE );
 
     if ( !cipher.ciphertext ) {
         throw ThresholdUtils::IsNotWellFormed( "ciphertext is null" );

--- a/threshold_encryption/ThresholdEncryption.h
+++ b/threshold_encryption/ThresholdEncryption.h
@@ -47,6 +47,19 @@ public:
     static std::vector< uint8_t > mockupEncrypt( const std::vector< uint8_t >& _message );
     static std::vector< uint8_t > mockupDecrypt( const std::vector< uint8_t >& _encryptedData );
 
+    struct EncryptMetaData {
+        // Optional associated data for AES CBC
+        // Is used at encryption and at decryption stages only. Does not obey to threshold
+        // guarantees since it is associated with symmetric encryption.
+        std::optional< std::vector< uint8_t > > associatedDataAesCbc;
+
+        // Optional associated data for TE
+        // Is used at encryption and validateEncryption stages only. Obeys to threshold guarantees
+        // as long as no party proceeds with the algorithm (partial decryption) in case
+        // validateEncryption fails with this associated data.
+        std::optional< std::vector< uint8_t > > assocaitedDataTE;
+    };
+
     /**
      * @brief Encrypts a message using threshold encryption.
      * This function generates a random AES key, and encrypts the message using this key.
@@ -58,39 +71,45 @@ public:
      * @return Ciphertext - Struct containing TE(AESKey) and AESKey(message)
      */
     static Ciphertext encrypt( const std::vector< uint8_t >& _message,
-        const TEPublicKey& _commonPublic,
-        const std::optional< std::vector< uint8_t > >& _associatedData = std::nullopt );
+        const TEPublicKey& _commonPublic, const EncryptMetaData& _metaData = EncryptMetaData() );
+
     static Ciphertext encrypt( const std::vector< uint8_t >& _message,
         const std::vector< TEPublicKey >& _commonPublic,
-        const std::optional< std::vector< uint8_t > >& _associatedData = std::nullopt );
+        const EncryptMetaData& _metaData = EncryptMetaData() );
 
     /**
-     * @brief Validates the TE ciphered key. SIngle threaded.
+     * @brief Validates the TE ciphered key. Single threaded.
      *
      * @param _cipheredKey The encrypted AESKey used to encrypt the message held by Ciphertext
      * struct
+     * @param _associatedDataTE Optional associated data used during encryption
      * @throws Exceptions in case validation fails
      */
-    static void validateEncryption( const CipheredKey& _cipheredKey );
+    static void validateEncryption( const CipheredKey& _cipheredKey,
+        const std::vector< uint8_t >* _associatedDataTE = nullptr );
 
     /**
      * @brief Validates a batch of TE ciphered keys. Same as above, but more performant
      * @param _ciphertexts Vector of encrypted AESKeys used to encrypt the message held by
      * Ciphertext struct
+     * @param _associatedDataTE Optional vector of associated data - one AAD per ciphertext
      * @return Vec of bools, each idx specifying if it was successfully validated or not.
      * Each idx corresponds to the same idx on _ciphertexts.
      */
     static std::vector< bool > validateEncryptionBatch(
-        const std::vector< CipheredKey >& _ciphertexts );
+        const std::vector< CipheredKey >& _ciphertexts,
+        const std::vector< std::vector< uint8_t > >* _associatedDataTE = nullptr );
 
     /**
      * @brief Validates a batch of TE ciphered keys in parallel. Same as above, but multi-threaded
      * @param _ciphertexts Vector of encrypted AESKeys used to encrypt the message held by
      * Ciphertext struct
+     * @param _associatedDataTE Optional vector of associated data - one AAD per ciphertext
      * @return Vec of bools, each idx specifying if it was successfully validated or not
      */
     static std::vector< bool > validateEncryptionBatchParallel(
-        const std::vector< CipheredKey >& _ciphertexts );
+        const std::vector< CipheredKey >& _ciphertexts,
+        const std::vector< std::vector< uint8_t > >* _associatedDataTE = nullptr );
 
     /**
      * @brief Generates a decryption share for the given ciphered key
@@ -110,10 +129,12 @@ public:
      * @param _cipheredKey The encrypted AESKey used to encrypt the message held by Ciphertext
      * struct
      * @param decryption_share The decryption share
+     * @param _associatedDataTE Optional TE AAD used during encryption
      * @throws Exception if the decryption share is not valid
      */
     static void validateDecryptionShare( const CipheredKey& _cipheredKey,
-        const TEDecryptionShare& _decryptionShare, const TEPublicKeyShare& _publicKey );
+        const TEDecryptionShare& _decryptionShare, const TEPublicKeyShare& _publicKey,
+        const std::vector< uint8_t >* _associatedDataTE = nullptr );
 
 
     /**
@@ -126,13 +147,15 @@ public:
      * `TEPublicKeyShare` each.
      * @param _decryptionShares Vector of decryption shares. Must be same size as _publicKeys.
      * @param _publicKeys Vector of public keys corresponding to the decryption shares.
+     * @param _associatedDataTE Optional vector of TE AAD - one per ciphertext
      * @return Vec of bools, each idx specifying if it was successfully validated or not.
      * Each idx corresponds to the same idx on _decryptionShares and _publicKeys.
      */
     static std::vector< bool > validateDecryptionSharesBatch(
         const std::vector< CipheredKey >& _cipheredKeys,
         const std::vector< TEDecryptionShare >& _decryptionShares,
-        const std::vector< TEPublicKeyShare >& _publicKeys );
+        const std::vector< TEPublicKeyShare >& _publicKeys,
+        const std::vector< std::vector< uint8_t > >* _associatedDataTE = nullptr );
 
     /**
      * @brief Validates a batch of decryption shares in parallel - same as above, but multi-threaded
@@ -140,7 +163,8 @@ public:
     static std::vector< bool > validateDecryptionSharesBatchParallel(
         const std::vector< CipheredKey >& _cipherTexts,
         const std::vector< TEDecryptionShare >& _decryptionShares,
-        const std::vector< TEPublicKeyShare >& _publicKeys );
+        const std::vector< TEPublicKeyShare >& _publicKeys,
+        const std::vector< std::vector< uint8_t > >* _associatedDataTE = nullptr );
 
     /**
      * @brief Combines decryption shares to reconstruct the original AES key.

--- a/threshold_encryption/ThresholdEncryption.h
+++ b/threshold_encryption/ThresholdEncryption.h
@@ -57,7 +57,7 @@ public:
         // Is used at encryption and validateEncryption stages only. Obeys to threshold guarantees
         // as long as no party proceeds with the algorithm (partial decryption) in case
         // validateEncryption fails with this associated data.
-        std::optional< std::vector< uint8_t > > assocaitedDataTE;
+        std::optional< std::vector< uint8_t > > associatedDataTE;
     };
 
     /**

--- a/threshold_encryption/encryptMessage.cpp
+++ b/threshold_encryption/encryptMessage.cpp
@@ -51,7 +51,7 @@ const char* encryptMessage( const char* data, const char* key,
 
     // set AAD TE if not empty
     if ( additionalAuthenticatedDataTE != nullptr && additionalAuthenticatedDataTE[0] != '\0' ) {
-        metaData.assocaitedDataTE =
+        metaData.associatedDataTE =
             libBLS::ThresholdUtils::hexCStringToBytes( additionalAuthenticatedDataTE );
     }
 
@@ -95,7 +95,7 @@ const char* encryptMessageDualKey( const char* data, const char* firstKey, const
 
     // set AAD TE if not empty
     if ( additionalAuthenticatedDataTE != nullptr && additionalAuthenticatedDataTE[0] != '\0' ) {
-        metaData.assocaitedDataTE =
+        metaData.associatedDataTE =
             libBLS::ThresholdUtils::hexCStringToBytes( additionalAuthenticatedDataTE );
     }
 

--- a/threshold_encryption/encryptMessage.cpp
+++ b/threshold_encryption/encryptMessage.cpp
@@ -27,8 +27,8 @@ along with libBLS. If not, see <https://www.gnu.org/licenses/>.
 
 extern "C" {
 
-const char* encryptMessage(
-    const char* data, const char* key, const char* additionalAuthenticatedData ) {
+const char* encryptMessage( const char* data, const char* key,
+    const char* additionalAuthenticatedDataAES, const char* additionalAuthenticatedDataTE ) {
     static std::string cipheredMessageStr;
 
     libBLS::init();
@@ -36,17 +36,29 @@ const char* encryptMessage(
     // convert from char into vec of bytes
     std::vector< uint8_t > messageBytes = libBLS::ThresholdUtils::hexCStringToBytes( data );
 
-    // convert from char into vec of bytes
-    std::vector< uint8_t > additionalAuthenticatedDataBytes =
-        libBLS::ThresholdUtils::hexCStringToBytes( additionalAuthenticatedData );
-
     // build public key
     std::string keyStr( key );
     libBLS::TEPublicKey commonPublic( keyStr, libBLS::Base::HEXA );
 
+    // build encrypt meta data
+    libBLS::ThresholdEncryption::EncryptMetaData metaData;
+
+    // set AAD AES if not empty
+    if ( additionalAuthenticatedDataAES != nullptr && additionalAuthenticatedDataAES[0] != '\0' ) {
+        metaData.associatedDataAesCbc =
+            libBLS::ThresholdUtils::hexCStringToBytes( additionalAuthenticatedDataAES );
+    }
+
+    // set AAD TE if not empty
+    if ( additionalAuthenticatedDataTE != nullptr && additionalAuthenticatedDataTE[0] != '\0' ) {
+        metaData.assocaitedDataTE =
+            libBLS::ThresholdUtils::hexCStringToBytes( additionalAuthenticatedDataTE );
+    }
+
     // encrypt message
-    libBLS::Ciphertext cipheredMessage = libBLS::ThresholdEncryption::encrypt(
-        messageBytes, commonPublic, additionalAuthenticatedDataBytes );
+    libBLS::Ciphertext cipheredMessage =
+        libBLS::ThresholdEncryption::encrypt( messageBytes, commonPublic, metaData );
+
     std::vector< uint8_t > cipheredMessageBytes = cipheredMessage.toBytes();
 
     cipheredMessageStr = libBLS::ThresholdUtils::bytesToHexString( cipheredMessageBytes );
@@ -55,17 +67,13 @@ const char* encryptMessage(
 }
 
 const char* encryptMessageDualKey( const char* data, const char* firstKey, const char* secondKey,
-    const char* additionalAuthenticatedData ) {
+    const char* additionalAuthenticatedDataAES, const char* additionalAuthenticatedDataTE ) {
     static std::string cipheredMessageStr;
 
     libBLS::init();
 
     // convert from char into vec of bytes
     std::vector< uint8_t > messageBytes = libBLS::ThresholdUtils::hexCStringToBytes( data );
-
-    // convert from char into vec of bytes
-    std::vector< uint8_t > additionalAuthenticatedDataBytes =
-        libBLS::ThresholdUtils::hexCStringToBytes( additionalAuthenticatedData );
 
     std::vector< libBLS::TEPublicKey > commonPublicKeys;
     // build public keys
@@ -76,9 +84,24 @@ const char* encryptMessageDualKey( const char* data, const char* firstKey, const
     commonPublicKeys.push_back( firstCommonPublic );
     commonPublicKeys.push_back( secondCommonPublic );
 
-    // encrypt message
-    libBLS::Ciphertext cipheredMessage = libBLS::ThresholdEncryption::encrypt(
-        messageBytes, commonPublicKeys, additionalAuthenticatedDataBytes );
+    // Build meta data
+    libBLS::ThresholdEncryption::EncryptMetaData metaData;
+
+    // set AAD AES if not empty
+    if ( additionalAuthenticatedDataAES != nullptr && additionalAuthenticatedDataAES[0] != '\0' ) {
+        metaData.associatedDataAesCbc =
+            libBLS::ThresholdUtils::hexCStringToBytes( additionalAuthenticatedDataAES );
+    }
+
+    // set AAD TE if not empty
+    if ( additionalAuthenticatedDataTE != nullptr && additionalAuthenticatedDataTE[0] != '\0' ) {
+        metaData.assocaitedDataTE =
+            libBLS::ThresholdUtils::hexCStringToBytes( additionalAuthenticatedDataTE );
+    }
+
+
+    libBLS::Ciphertext cipheredMessage =
+        libBLS::ThresholdEncryption::encrypt( messageBytes, commonPublicKeys, metaData );
     std::vector< uint8_t > cipheredMessageBytes = cipheredMessage.toBytes();
 
     cipheredMessageStr = libBLS::ThresholdUtils::bytesToHexString( cipheredMessageBytes );

--- a/threshold_encryption/threshold_encryption.cpp
+++ b/threshold_encryption/threshold_encryption.cpp
@@ -55,15 +55,22 @@ std::string TE::Hash( const algebra::G2Point& Y ) {
     return sha256hex;
 }
 
-algebra::G1Point TE::HashToGroup( const algebra::G2Point& U, const AES256Key& V ) {
+algebra::G1Point TE::HashToGroup(
+    const algebra::G2Point& U, const AES256Key& V, const std::vector< uint8_t >* associatedData ) {
     // assumed that U lies in G2
 
     auto uStr = U.toStringArray( Base::DEC );
     std::string vStr = ThresholdUtils::bytesToHexString( V );
 
+    // Build hash input: U coordinates + V + optional AAD
+    std::string hashInput = uStr[0] + uStr[1] + uStr[2] + uStr[3] + vStr;
+    if ( associatedData && !associatedData->empty() ) {
+        std::string aadStr = ThresholdUtils::bytesToHexString( *associatedData );
+        hashInput += aadStr;
+    }
+
     // hash 2x
-    const std::string sha256hex =
-        ThresholdUtils::sha256( uStr[0] + uStr[1] + uStr[2] + uStr[3] + vStr );
+    const std::string sha256hex = ThresholdUtils::sha256( hashInput );
     std::string hashStr = ThresholdUtils::sha256( sha256hex );
 
     std::vector< uint8_t > bytes = ThresholdUtils::hexCStringToBytes( hashStr.c_str() );
@@ -77,13 +84,15 @@ algebra::G1Point TE::HashToGroup( const algebra::G2Point& U, const AES256Key& V 
 }
 
 
-CipheredKeyResult TE::getCiphertext( const AES256Key& key, const algebra::G2Point& commonPublic ) {
-    return getCiphertext( key, std::vector< algebra::G2Point >{ commonPublic } );
+CipheredKeyResult TE::getCiphertext( const AES256Key& key, const algebra::G2Point& commonPublic,
+    const std::vector< uint8_t >* associatedDataTE ) {
+    return getCiphertext( key, std::vector< algebra::G2Point >{ commonPublic }, associatedDataTE );
 }
 
 
-CipheredKeyResult TE::getCiphertext(
-    const AES256Key& key, const std::vector< algebra::G2Point >& commonPublicVector ) {
+CipheredKeyResult TE::getCiphertext( const AES256Key& key,
+    const std::vector< algebra::G2Point >& commonPublicVector,
+    const std::vector< uint8_t >* associatedDataTE ) {
     algebra::FrScalar r = algebra::FrScalar::random();
 
     while ( r.isZero() ) {
@@ -114,7 +123,7 @@ CipheredKeyResult TE::getCiphertext(
 
         algebra::G1Point W, H;
 
-        H = HashToGroup( U, V );
+        H = HashToGroup( U, V, associatedDataTE );
         W = r * H;
 
         cipheredKeys.emplace_back( U, V, W );
@@ -146,30 +155,34 @@ CipheredKeyResult TE::getCiphertext(
  */
 CipherResult TE::encryptWithAES( const std::vector< uint8_t >& message,
     const algebra::G2Point& commonPublic,
-    const std::optional< std::vector< uint8_t > >& associatedData ) {
-    return encryptWithAES(
-        message, std::vector< algebra::G2Point >{ commonPublic }, associatedData );
+    const std::optional< std::vector< uint8_t > >& associatedDataAES,
+    const std::optional< std::vector< uint8_t > >& associatedDataTE ) {
+    return encryptWithAES( message, std::vector< algebra::G2Point >{ commonPublic },
+        associatedDataAES, associatedDataTE );
 }
 
 CipherResult TE::encryptWithAES( const std::vector< uint8_t >& message,
     const std::vector< algebra::G2Point >& commonPublic,
-    const std::optional< std::vector< uint8_t > >& associatedData ) {
+    const std::optional< std::vector< uint8_t > >& associatedDataAES,
+    const std::optional< std::vector< uint8_t > >& associatedDataTE ) {
     // create random AES key
     AES256Key key;
     if ( RAND_bytes( key.data(), key.size() ) != 1 ) {
         throw ThresholdUtils::IsNotWellFormed( "Failed to generate random key" );
     }
-    // cipher aes key
-    CipheredKeyResult result = getCiphertext( key, commonPublic );
+    // cipher aes key (with optional TE AAD)
+    const std::vector< uint8_t >* aadPtr =
+        associatedDataTE.has_value() ? &*associatedDataTE : nullptr;
+    CipheredKeyResult result = getCiphertext( key, commonPublic, aadPtr );
 
     // append random secret to end of message
     std::vector< uint8_t > messageToCipher( message );
     messageToCipher.insert(
         messageToCipher.end(), result.randomSecret.begin(), result.randomSecret.end() );
 
-    // cipher message + random secret using AES key (with optional AAD)
+    // cipher message + random secret using AES key (with optional AES AAD)
     AesGcmCipher aesGcmCipher{ key };
-    auto encryptedMessage = aesGcmCipher.encrypt( messageToCipher, associatedData );
+    auto encryptedMessage = aesGcmCipher.encrypt( messageToCipher, associatedDataAES );
 
     std::shared_ptr< Ciphertext > ciphertext =
         std::make_shared< Ciphertext >( result.ciphertext, encryptedMessage );
@@ -251,10 +264,10 @@ algebra::G2Point TE::getDecryptionShare(
  * @return false if either the ciphertext is invalid or the decryption share verification fails
  */
 bool TE::Verify( const CipheredKey& ciphertext, const algebra::G2Point& decryptionShare,
-    const algebra::G2Point& publicKey ) {
+    const algebra::G2Point& publicKey, const std::vector< uint8_t >* associatedDataTE ) {
     auto [U, V, W] = ciphertext;
 
-    algebra::G1Point H = HashToGroup( U, V );
+    algebra::G1Point H = HashToGroup( U, V, associatedDataTE );
     // no need to validate ciphertext's pairing - assumed to be validated already via
     // `validateEncryption` call
 
@@ -283,7 +296,8 @@ bool TE::Verify( const CipheredKey& ciphertext, const algebra::G2Point& decrypti
  */
 std::vector< bool > TE::VerifyBatch( const std::vector< CipheredKey >& ciphertexts,
     const std::vector< algebra::G2Point >& decryptionShares,
-    const std::vector< algebra::G2Point >& publicKeys ) {
+    const std::vector< algebra::G2Point >& publicKeys,
+    const std::vector< std::vector< uint8_t > >* associatedDataTE ) {
     const size_t size = decryptionShares.size();
     const size_t numberOfBatches = ciphertexts.size();
 
@@ -301,15 +315,22 @@ std::vector< bool > TE::VerifyBatch( const std::vector< CipheredKey >& ciphertex
             "decryption shares and public keys must have same size" );
     }
 
+    if ( associatedDataTE && associatedDataTE->size() != numberOfBatches ) {
+        throw ThresholdUtils::IncorrectInput(
+            "associated data size must match number of ciphertexts" );
+    }
+
     std::vector< algebra::G1Point > g1P1s;
     std::vector< algebra::G1Point > g1P2s;
     g1P1s.reserve( ciphertexts.size() );
     g1P2s.reserve( ciphertexts.size() );
 
-    for ( const auto& cipher : ciphertexts ) {
-        const auto& [U, V, W] = cipher;
+    for ( size_t i = 0; i < ciphertexts.size(); ++i ) {
+        const auto& [U, V, W] = ciphertexts[i];
+        const std::vector< uint8_t >* aadPtr =
+            associatedDataTE ? &associatedDataTE->at( i ) : nullptr;
 
-        algebra::G1Point H = HashToGroup( U, V );
+        algebra::G1Point H = HashToGroup( U, V, aadPtr );
         // no need to validate H - assumes H has been validated already when performing the
         // ciphertext validation at the start of TE process
 

--- a/threshold_encryption/threshold_encryption.h
+++ b/threshold_encryption/threshold_encryption.h
@@ -27,337 +27,21 @@ along with libBLS. If not, see <https://www.gnu.org/licenses/>.
 #include <array>
 #include <optional>
 #include <string>
-#include <tuple>
 #include <utility>
 #include <vector>
 
-#include "AesGcmCipher.h"
 #include "TEBase.h"
 #include "backends/algebra.hpp"
 #include <tools/utils.h>
 
-// TODO - remove this
-#include "benchmarks/ScopedTimer.hpp"
-#include <iostream>
+#include "CipheredKey.h"
+#include "Ciphertext.h"
 
 
 namespace libBLS {
 
 constexpr size_t CYPHERTEXT_LENGTH = 64;
-
-constexpr size_t RANDOM_SECRET_SIZE_BYTES = MAX_FIELD_ELEMENT_SIZE_BYTES;
 using RandSecret = std::array< uint8_t, RANDOM_SECRET_SIZE_BYTES >;
-
-/**
- * @brief Holds the AES key ciphered via
- * Thresgold Encryption
- */
-struct CipheredKey {
-    static constexpr size_t CIPHERED_KEY_SIZE_BYTES =
-        algebra::G2Point::SIZE_BYTES + AES_256_KEY_SIZE_BYTES + algebra::G1Point::SIZE_BYTES;
-
-    algebra::G2Point U;
-    AES256Key V;
-    algebra::G1Point W;
-
-public:
-    CipheredKey() = default;
-    CipheredKey( algebra::G2Point _U, AES256Key _V, algebra::G1Point _W, bool _validate = true )
-        : U( _U ), V( std::move( _V ) ), W( _W ) {
-        if ( _validate )
-            validate();
-    }
-
-    bool operator==( const CipheredKey& other ) const {
-        return ( U == other.U ) && ( V == other.V ) && ( W == other.W );
-    }
-
-    /**
-     * @brief Converts CipheredKey to bytes
-     * The byte format returned is: `[ U | V | W ]`
-     * where `U` and `W` are elements of G2 and G1 groups respectively,
-     * and `V` is a fixed size AES256Key.
-     *
-     * Final byte representation is always of fixed size.
-     */
-    std::array< uint8_t, CIPHERED_KEY_SIZE_BYTES > toBytes() const {
-        std::array< uint8_t, CIPHERED_KEY_SIZE_BYTES > bytes;
-        uint8_t* source = bytes.data();
-        // set U component
-        auto uBytes = U.toByteArray();
-        std::memcpy( source, uBytes.data(), uBytes.size() );
-        source += uBytes.size();
-        // set V commponent
-        std::memcpy( source, V.data(), V.size() );
-        source += V.size();
-        // set W component
-        auto wBytes = W.toByteArray();
-        std::memcpy( source, wBytes.data(), wBytes.size() );
-
-        return bytes;
-    }
-
-    /**
-     * @brief Converts bytes to CipheredKey
-     */
-    static CipheredKey fromBytes(
-        std::array< uint8_t, CIPHERED_KEY_SIZE_BYTES > _bytes, bool _validate = true ) {
-        std::array< uint8_t, G2_SIZE_BYTES > uBytes;
-        std::array< uint8_t, AES_256_KEY_SIZE_BYTES > vBytes;
-        std::array< uint8_t, G1_SIZE_BYTES > wBytes;
-
-        uint8_t* offset = _bytes.data();
-        // Get U bytes
-        std::memcpy( uBytes.data(), offset, G2_SIZE_BYTES );
-        offset += G2_SIZE_BYTES;
-        // Get V bytes
-        std::memcpy( vBytes.data(), offset, AES_256_KEY_SIZE_BYTES );
-        offset += AES_256_KEY_SIZE_BYTES;
-        // Get W bytes
-        std::memcpy( wBytes.data(), offset, G1_SIZE_BYTES );
-
-        // Convert to CipheredKey components
-        algebra::G2Point U = algebra::G2Point::fromBytes( uBytes );
-        algebra::G1Point W = algebra::G1Point::fromBytes( wBytes );
-
-        // constructor performs validation
-        return CipheredKey( U, vBytes, W, _validate );
-    }
-
-    /**
-     * @brief Validates the CipheredKey
-     * @throw NotWellFormed if the key is not well formed
-     */
-    void validate() const {
-        W.validate();
-        U.validate();
-    }
-
-    static CipheredKey random() {
-        algebra::G2Point U = algebra::G2Point::random();
-        AES256Key V;
-        RAND_bytes( V.data(), V.size() );
-        algebra::G1Point W = algebra::G1Point::random();
-        return CipheredKey( U, V, W );
-    }
-
-    /**
-     * Converts U component of the key to string
-     */
-    std::string getDecryptionShareInput() {
-        U.toAffineCoordinates();
-        return U.toString( Base::HEXA );
-    }
-
-    static std::vector< std::string > getDecryptionShareInputBatch(
-        const std::vector< CipheredKey >& keys ) {
-        std::vector< algebra::G2Point > U_points;
-        U_points.reserve( keys.size() );
-        for ( const auto& key : keys ) {
-            U_points.push_back( key.U );
-        }
-
-        // batch convert all to affine coordinates
-        toAffineVec( U_points );
-
-        std::vector< std::string > res;
-        res.reserve( keys.size() );
-        for ( const auto& U : U_points ) {
-            auto uSplitted = U.toString( Base::HEXA );
-            res.push_back( uSplitted );
-        }
-
-        return res;
-    }
-
-    const algebra::G2Point& getU() const { return U; }
-    const AES256Key& getV() const { return V; }
-    const algebra::G1Point& getW() const { return W; }
-};
-
-/**
- * @brief Holds the ciphered AES keys (vector), as well as the data
- * ciphered with AES key.
- */
-struct Ciphertext {
-    std::vector< CipheredKey > keys;
-    std::shared_ptr< std::vector< uint8_t > > data;
-
-public:
-    bool operator==( const Ciphertext& other ) const {
-        bool baseParams = keys == other.keys;
-        if ( data && other.data ) {
-            return baseParams && ( *data == *other.data );
-        }
-        return baseParams;
-    }
-
-    Ciphertext() = default;
-
-    Ciphertext( const std::vector< CipheredKey >& _keys, const std::vector< uint8_t >& _data,
-        bool _validate = true )
-        : keys( _keys ), data( std::make_shared< std::vector< uint8_t > >( _data ) ) {
-        if ( _validate )
-            validate();
-    }
-
-    Ciphertext(
-        const CipheredKey& _key, const std::vector< uint8_t >& _data, bool _validate = true )
-        : keys( { _key } ), data( std::make_shared< std::vector< uint8_t > >( _data ) ) {
-        if ( _validate )
-            validate();
-    }
-
-    // Constructor for exactly two keys
-    Ciphertext( const CipheredKey& _key1, const CipheredKey& _key2,
-        const std::vector< uint8_t >& _data, bool _validate = true )
-        : keys( { _key1, _key2 } ), data( std::make_shared< std::vector< uint8_t > >( _data ) ) {
-        if ( _validate )
-            validate();
-    }
-
-    const std::vector< uint8_t >& getData() const {
-        if ( !data ) {
-            throw ThresholdUtils::IncorrectInput( "Cyphertext data is not initialized" );
-        }
-        return *data;
-    }
-
-    /**
-     * @brief Converts Ciphertext to bytes
-     * The byte format returned is: `[ num_keys | key1 | key2 | ... | data ]`
-     *
-     * where `data` can be of arbitrary size, each `key` is a fixed size,
-     * and `num_keys` is a 1-byte integer indicating the number of keys.
-     */
-    const std::vector< uint8_t > toBytes() const {
-        if ( !data ) {
-            throw ThresholdUtils::IncorrectInput( "Cyphertext data is not initialized" );
-        }
-
-        // Calculate total size needed
-        size_t totalSize = sizeof( uint8_t ) +  // for number of keys
-                           ( keys.size() * CipheredKey::CIPHERED_KEY_SIZE_BYTES ) +  // for all keys
-                           data->size();                                             // for data
-
-        std::vector< uint8_t > bytes;
-        bytes.reserve( totalSize );
-
-        // Add number of keys
-        uint8_t numKeys = static_cast< uint8_t >( keys.size() );
-        bytes.push_back( numKeys );
-
-        // Add each key
-        for ( const auto& key : keys ) {
-            std::array< uint8_t, CipheredKey::CIPHERED_KEY_SIZE_BYTES > keyBytes = key.toBytes();
-            bytes.insert( bytes.end(), keyBytes.begin(), keyBytes.end() );
-        }
-
-        // Add data
-        bytes.insert( bytes.end(), data->begin(), data->end() );
-
-        return bytes;
-    }
-
-    /**
-     * @brief Converts bytes to Ciphertext
-     */
-    static Ciphertext fromBytes( std::vector< uint8_t >& bytes, bool _validate = true ) {
-        // we require at least 1 byte for num_keys + one key + random secret + 1 byte for data
-        if ( bytes.size() <=
-             sizeof( uint8_t ) + CipheredKey::CIPHERED_KEY_SIZE_BYTES + RANDOM_SECRET_SIZE_BYTES ) {
-            throw ThresholdUtils::IncorrectInput( "Cyphertext data is too short" );
-        }
-
-        size_t offset = 0;
-
-        // Get number of keys
-        uint8_t numKeys;
-        std::memcpy( &numKeys, bytes.data() + offset, sizeof( uint8_t ) );
-        offset += sizeof( uint8_t );
-
-        if ( numKeys == 0 || numKeys > 2 )
-            throw ThresholdUtils::IncorrectInput( "Ciphertext must contain exactly 1 or 2 keys" );
-
-        // Check that the input matches the number of keys
-        size_t expectedMinSize =
-            sizeof( uint8_t ) + ( numKeys * CipheredKey::CIPHERED_KEY_SIZE_BYTES ) +
-            RANDOM_SECRET_SIZE_BYTES + 1;  // +1 for at least 1 byte of actual data
-        if ( bytes.size() < expectedMinSize )
-            throw ThresholdUtils::IncorrectInput(
-                "Cyphertext data is too short for specified number of keys" );
-
-        // Extract keys
-        std::vector< CipheredKey > keys;
-        keys.reserve( numKeys );
-
-        for ( size_t i = 0; i < numKeys; ++i ) {
-            std::array< uint8_t, CipheredKey::CIPHERED_KEY_SIZE_BYTES > keyBytes;
-            std::memcpy(
-                keyBytes.data(), bytes.data() + offset, CipheredKey::CIPHERED_KEY_SIZE_BYTES );
-            offset += CipheredKey::CIPHERED_KEY_SIZE_BYTES;
-
-            // do not validate CipheredKey here
-            // if validation is enabled, CipheredKey is validated in Ciphertext's constructor
-            // otherwise we don't need validation at all
-            keys.push_back( CipheredKey::fromBytes( keyBytes, false ) );
-        }
-
-        // Get data bytes
-        std::vector< uint8_t > data( bytes.begin() + offset, bytes.end() );
-
-        return Ciphertext( keys, data, _validate );
-    }
-
-    /**
-     * @brief Validates the Ciphertext
-     * @throw NotWellFormed if the it fails the validation
-     */
-    void validate() const {
-        if ( keys.empty() || keys.size() > 2 )
-            throw ThresholdUtils::IsNotWellFormed( "Ciphertext must contain exactly 1 or 2 keys" );
-
-        for ( const auto& key : keys ) {
-            key.validate();
-        }
-
-        if ( !data ) {
-            throw ThresholdUtils::IsNotWellFormed( "Cyphertext data is not initialized" );
-        }
-
-        // actual data without random secret must be at least 1 byte long
-        if ( data->size() <= RANDOM_SECRET_SIZE_BYTES ) {
-            throw ThresholdUtils::IsNotWellFormed(
-                "Cyphertext data is too short to hold random secret and at least 1 byte of data." );
-        }
-    }
-
-    /**
-     * @brief Returns the vector of keys in the Ciphertext
-     */
-    const std::vector< CipheredKey >& getKeys() const { return keys; }
-
-    /**
-     * @brief keeps only one key for validation and decryption
-     * @param idx - index of the key to keep
-     */
-    void keepKey( size_t _idx ) {
-        if ( _idx >= keys.size() || keys.size() != 2 )
-            throw ThresholdUtils::IncorrectInput(
-                "Key index is greater than number of the keys in ciphertext" );
-        keys.erase( keys.begin() + ( keys.size() - _idx - 1 ) );
-    }
-
-    /**
-     * @brief get a CipheredKey for validation and decryption
-     * @throw IncorrectInput if there are 0 or 2 keys to choose
-     */
-    const CipheredKey& getTargetKey() const {
-        if ( keys.size() != 1 )
-            throw ThresholdUtils::IncorrectInput( "Cannot choose a target key" );
-        return keys.front();
-    }
-};
 
 /**
  * @brief The result of the encryption process
@@ -399,17 +83,23 @@ public:
      *
      * @note This is an auxiliar function, used within `encryptWithAES`
      */
-    static CipheredKeyResult getCiphertext(
-        const AES256Key& key, const algebra::G2Point& commonPublic );
-    static CipheredKeyResult getCiphertext(
-        const AES256Key& key, const std::vector< algebra::G2Point >& commonPublic );
+    static CipheredKeyResult getCiphertext( const AES256Key& key,
+        const algebra::G2Point& commonPublic,
+        const std::vector< uint8_t >* associatedDataTE = nullptr );
+
+    static CipheredKeyResult getCiphertext( const AES256Key& key,
+        const std::vector< algebra::G2Point >& commonPublic,
+        const std::vector< uint8_t >* associatedDataTE = nullptr );
 
     static CipherResult encryptWithAES( const std::vector< uint8_t >& message,
         const algebra::G2Point& commonPublic,
-        const std::optional< std::vector< uint8_t > >& associatedData = std::nullopt );
+        const std::optional< std::vector< uint8_t > >& associatedDataAES = std::nullopt,
+        const std::optional< std::vector< uint8_t > >& associatedDataTE = std::nullopt );
+
     static CipherResult encryptWithAES( const std::vector< uint8_t >& message,
         const std::vector< algebra::G2Point >& commonPublic,
-        const std::optional< std::vector< uint8_t > >& associatedData = std::nullopt );
+        const std::optional< std::vector< uint8_t > >& associatedDataAES = std::nullopt,
+        const std::optional< std::vector< uint8_t > >& associatedDataTE = std::nullopt );
 
     static std::pair< std::string, RandSecret > encryptMessage(
         const std::vector< uint8_t >& message, const std::string& commonPublic );
@@ -419,16 +109,19 @@ public:
     static algebra::G2Point getDecryptionShare(
         const CipheredKey& ciphertext, const algebra::FrScalar& secretKey );
 
-    static algebra::G1Point HashToGroup( const algebra::G2Point& U, const AES256Key& V );
+    static algebra::G1Point HashToGroup( const algebra::G2Point& U, const AES256Key& V,
+        const std::vector< uint8_t >* associatedData = nullptr );
 
     static std::string Hash( const algebra::G2Point& Y );
 
     static bool Verify( const CipheredKey& ciphertext, const algebra::G2Point& decryptionShare,
-        const algebra::G2Point& publicKey );
+        const algebra::G2Point& publicKey,
+        const std::vector< uint8_t >* associatedDataTE = nullptr );
 
     static std::vector< bool > VerifyBatch( const std::vector< CipheredKey >& ciphertexts,
         const std::vector< algebra::G2Point >& decryptionShares,
-        const std::vector< algebra::G2Point >& publicKeys );
+        const std::vector< algebra::G2Point >& publicKeys,
+        const std::vector< std::vector< uint8_t > >* associatedDataTE = nullptr );
 
     AES256Key CombineShares( const CipheredKey& ciphertext,
         const std::vector< std::pair< algebra::G2Point, size_t > >& decryptionShare );


### PR DESCRIPTION
### Description

Addeed support for AAD at TE level:
- `encrypt` now takes optional AAD for both AES and TE
- TE AAD can be used during 2 different steps during validation: 
    - `validateEncryption`
    - `validateDecryptShare`
    
Refactored `Ciphertext` and `CipheredKey` into their own files
    
### Tests

Modified current tests to pass AAD values & test with wrong values / no value at all

Fixes #279 