### PR TITLE
Seeded Deterministic Encryption

### DIFF
--- a/test/test_TE_wrappers.cpp
+++ b/test/test_TE_wrappers.cpp
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE( TEEncryptDecryptWithAAD ) {
     std::vector< uint8_t > aadTE = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
 
     // Encrypt with both AADs
-    libBLS::ThresholdEncryption::EncryptMetaData metaData;
+    libBLS::EncryptMetaData metaData;
     metaData.associatedDataAesCbc = aadAES;
     metaData.associatedDataTE = aadTE;
     libBLS::Ciphertext cypher =
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE( TEEncryptDecryptWithWrongAAD ) {
     std::vector< uint8_t > wrong_aadTE = { 0xAA, 0xBB, 0xCC, 0xDD };
 
     // Encrypt with both AADs
-    libBLS::ThresholdEncryption::EncryptMetaData metaData;
+    libBLS::EncryptMetaData metaData;
     metaData.associatedDataAesCbc = aadAES;
     metaData.associatedDataTE = aadTE;
     libBLS::Ciphertext cypher =
@@ -195,7 +195,7 @@ BOOST_AUTO_TEST_CASE( TEValidateDecryptionShareWithWrongAAD ) {
     std::vector< uint8_t > aadTE = { 0x01, 0x02, 0x03, 0x04 };
     std::vector< uint8_t > wrong_aadTE = { 0xAA, 0xBB, 0xCC, 0xDD };
 
-    libBLS::ThresholdEncryption::EncryptMetaData metaData;
+    libBLS::EncryptMetaData metaData;
     metaData.associatedDataTE = aadTE;
     libBLS::Ciphertext cypher =
         libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic, metaData );
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE( TEEncryptWithTEAADOnly ) {
 
     std::vector< uint8_t > aadTE = { 0x01, 0x02, 0x03, 0x04 };
 
-    libBLS::ThresholdEncryption::EncryptMetaData metaData;
+    libBLS::EncryptMetaData metaData;
     metaData.associatedDataTE = aadTE;  // Only TE AAD, no AES AAD
 
     libBLS::Ciphertext cypher =
@@ -279,7 +279,7 @@ BOOST_AUTO_TEST_CASE( TEEncryptWithAESAADOnly ) {
 
     std::vector< uint8_t > aadAES = { 0xDE, 0xAD, 0xBE, 0xEF };
 
-    libBLS::ThresholdEncryption::EncryptMetaData metaData;
+    libBLS::EncryptMetaData metaData;
     metaData.associatedDataAesCbc = aadAES;  // Only AES AAD, no TE AAD
 
     libBLS::Ciphertext cypher =
@@ -324,7 +324,7 @@ BOOST_AUTO_TEST_CASE( TEEncryptWithEmptyAAD ) {
     std::vector< uint8_t > emptyAadAES = {};
     std::vector< uint8_t > emptyAadTE = {};
 
-    libBLS::ThresholdEncryption::EncryptMetaData metaData;
+    libBLS::EncryptMetaData metaData;
     metaData.associatedDataAesCbc = emptyAadAES;
     metaData.associatedDataTE = emptyAadTE;
 
@@ -366,7 +366,7 @@ BOOST_AUTO_TEST_CASE( TEValidateWithoutAADOnAADEncrypted ) {
 
     std::vector< uint8_t > aadTE = { 0x01, 0x02, 0x03, 0x04 };
 
-    libBLS::ThresholdEncryption::EncryptMetaData metaData;
+    libBLS::EncryptMetaData metaData;
     metaData.associatedDataTE = aadTE;
 
     libBLS::Ciphertext cypher =
@@ -400,7 +400,7 @@ BOOST_AUTO_TEST_CASE( TEBatchValidationWithAAD ) {
         std::vector< uint8_t > aadTE = { 0x01, 0x02, 0x03, static_cast< uint8_t >( i ) };
         aadVec.push_back( aadTE );
 
-        libBLS::ThresholdEncryption::EncryptMetaData metaData;
+        libBLS::EncryptMetaData metaData;
         metaData.associatedDataTE = aadTE;
 
         libBLS::Ciphertext cypher =
@@ -428,6 +428,76 @@ BOOST_AUTO_TEST_CASE( TEBatchValidationWithAAD ) {
     for ( size_t i = 0; i < batchSize; ++i ) {
         BOOST_REQUIRE( wrongResults[i] == false );
     }
+}
+
+
+BOOST_AUTO_TEST_CASE( TEEncryptDeterministicSeededKeyAndScalar ) {
+    const size_t numAll = 4;
+    const size_t numSigned = 3;
+
+    keys keys = generateKeys( numSigned, numAll );
+    std::vector< uint8_t > message = randomByteVec( 100 );
+
+    std::array< uint8_t, libBLS::AES_256_KEY_SIZE_BYTES > seedA{};
+    std::array< uint8_t, libBLS::AES_256_KEY_SIZE_BYTES > seedB{};
+    seedA.fill( 0x42 );
+    seedB.fill( 0x43 );
+
+    std::vector< libBLS::algebra::G2Point > rawPublicKeys =
+        { keys.commonPublic.getPublicKeyRaw() };
+
+    libBLS::EncryptMetaData metaDataA;
+    metaDataA.seed = seedA;
+
+    libBLS::CipherResult cipher1 = libBLS::TE::encryptWithAES( message, rawPublicKeys, metaDataA );
+    libBLS::CipherResult cipher2 = libBLS::TE::encryptWithAES( message, rawPublicKeys, metaDataA );
+
+    BOOST_REQUIRE( cipher1.ciphertext );
+    BOOST_REQUIRE( cipher2.ciphertext );
+    BOOST_CHECK( cipher1.randomSecret == cipher2.randomSecret );
+    BOOST_CHECK( cipher1.ciphertext->getKeys() == cipher2.ciphertext->getKeys() );
+    BOOST_CHECK( cipher1.ciphertext->toBytes() == cipher2.ciphertext->toBytes() );
+
+    libBLS::EncryptMetaData metaDataB;
+    metaDataB.seed = seedB;
+    libBLS::CipherResult cipher3 = libBLS::TE::encryptWithAES( message, rawPublicKeys, metaDataB );
+
+    BOOST_REQUIRE( cipher3.ciphertext );
+    BOOST_CHECK( cipher1.randomSecret != cipher3.randomSecret );
+    BOOST_CHECK( cipher1.ciphertext->getKeys() != cipher3.ciphertext->getKeys() );
+    BOOST_CHECK( cipher1.ciphertext->toBytes() != cipher3.ciphertext->toBytes() );
+
+    libBLS::EncryptMetaData metaDataNoSeed;
+    libBLS::CipherResult cipher4 =
+        libBLS::TE::encryptWithAES( message, rawPublicKeys, metaDataNoSeed );
+
+    BOOST_REQUIRE( cipher4.ciphertext );
+    BOOST_CHECK( cipher1.ciphertext->getKeys() != cipher4.ciphertext->getKeys() );
+    BOOST_CHECK( cipher1.ciphertext->toBytes() != cipher4.ciphertext->toBytes() );
+
+    std::vector< libBLS::TEPublicKeyShare > publicKeyShares;
+    publicKeyShares.reserve( numSigned );
+    for ( size_t i = 0; i < numSigned; ++i ) {
+        publicKeyShares.emplace_back( libBLS::TEPublicKeyShare( keys.secretKeys[i] ) );
+    }
+
+    const libBLS::CipheredKey& cipheredKey1 = cipher1.ciphertext->getKeys().at( 0 );
+    libBLS::ThresholdEncryption::validateEncryption( cipheredKey1, nullptr );
+
+    libBLS::TEDecryptSet decryptSet1( numSigned, numAll );
+    for ( size_t i = 0; i < numSigned; ++i ) {
+        libBLS::TEDecryptionShare decrShare =
+            libBLS::ThresholdEncryption::partialDecrypt( cipheredKey1, keys.secretKeys[i] );
+        libBLS::ThresholdEncryption::validateDecryptionShare(
+            cipheredKey1, decrShare, publicKeyShares[i], nullptr );
+        decryptSet1.addDecryptShare( decrShare );
+    }
+
+    libBLS::AES256Key keyDecrypted1 =
+        libBLS::ThresholdEncryption::combineShares( cipheredKey1, decryptSet1 );
+    std::vector< uint8_t > decryptedMsg1 =
+        libBLS::ThresholdEncryption::decrypt( *cipher1.ciphertext, keyDecrypted1, std::nullopt );
+    BOOST_REQUIRE( decryptedMsg1 == message );
 }
 
 

--- a/test/test_TE_wrappers.cpp
+++ b/test/test_TE_wrappers.cpp
@@ -443,8 +443,7 @@ BOOST_AUTO_TEST_CASE( TEEncryptDeterministicSeededKeyAndScalar ) {
     seedA.fill( 0x42 );
     seedB.fill( 0x43 );
 
-    std::vector< libBLS::algebra::G2Point > rawPublicKeys =
-        { keys.commonPublic.getPublicKeyRaw() };
+    std::vector< libBLS::algebra::G2Point > rawPublicKeys = { keys.commonPublic.getPublicKeyRaw() };
 
     libBLS::EncryptMetaData metaDataA;
     metaDataA.seed = seedA;
@@ -500,6 +499,141 @@ BOOST_AUTO_TEST_CASE( TEEncryptDeterministicSeededKeyAndScalar ) {
     BOOST_REQUIRE( decryptedMsg1 == message );
 }
 
+// Cross-node determinism - two independent "nodes" with same seed produce identical output
+BOOST_AUTO_TEST_CASE( TESeededCrossNodeDeterminism ) {
+    const size_t numAll = 4;
+    const size_t numSigned = 3;
+
+    keys keys = generateKeys( numSigned, numAll );
+    std::vector< uint8_t > message = randomByteVec( 100 );
+
+    // Fixed seed that both "nodes" will use
+    std::array< uint8_t, libBLS::AES_256_KEY_SIZE_BYTES > sharedSeed{};
+    sharedSeed.fill( 0xAB );
+
+    std::vector< libBLS::algebra::G2Point > rawPublicKeys = { keys.commonPublic.getPublicKeyRaw() };
+
+    // Simulate Node A encryption
+    libBLS::EncryptMetaData metaDataNodeA;
+    metaDataNodeA.seed = sharedSeed;
+    libBLS::CipherResult cipherNodeA =
+        libBLS::TE::encryptWithAES( message, rawPublicKeys, metaDataNodeA );
+
+    // Simulate Node B encryption (independent, same seed)
+    libBLS::EncryptMetaData metaDataNodeB;
+    metaDataNodeB.seed = sharedSeed;
+    libBLS::CipherResult cipherNodeB =
+        libBLS::TE::encryptWithAES( message, rawPublicKeys, metaDataNodeB );
+
+    // Both nodes must produce identical ciphertexts
+    BOOST_REQUIRE( cipherNodeA.ciphertext );
+    BOOST_REQUIRE( cipherNodeB.ciphertext );
+    BOOST_CHECK( cipherNodeA.randomSecret == cipherNodeB.randomSecret );
+    BOOST_CHECK( cipherNodeA.ciphertext->toBytes() == cipherNodeB.ciphertext->toBytes() );
+    BOOST_CHECK( cipherNodeA.ciphertext->getKeys() == cipherNodeB.ciphertext->getKeys() );
+    BOOST_CHECK( cipherNodeA.ciphertext->getData() == cipherNodeB.ciphertext->getData() );
+}
+
+// Multiple message sequence - same seed encrypting multiple messages in order
+BOOST_AUTO_TEST_CASE( TESeededMultipleMessageSequence ) {
+    const size_t numAll = 4;
+    const size_t numSigned = 3;
+
+    keys keys = generateKeys( numSigned, numAll );
+
+    std::vector< uint8_t > msg1 = randomByteVec( 50 );
+    std::vector< uint8_t > msg2 = randomByteVec( 75 );
+    std::vector< uint8_t > msg3 = randomByteVec( 100 );
+
+    std::array< uint8_t, libBLS::AES_256_KEY_SIZE_BYTES > seed{};
+    seed.fill( 0xCD );
+
+    std::vector< libBLS::algebra::G2Point > rawPublicKeys = { keys.commonPublic.getPublicKeyRaw() };
+
+    // Node A encrypts 3 messages in sequence
+    libBLS::EncryptMetaData metaA1, metaA2, metaA3;
+    metaA1.seed = seed;
+    metaA2.seed = seed;
+    metaA3.seed = seed;
+    auto cipherA1 = libBLS::TE::encryptWithAES( msg1, rawPublicKeys, metaA1 );
+    auto cipherA2 = libBLS::TE::encryptWithAES( msg2, rawPublicKeys, metaA2 );
+    auto cipherA3 = libBLS::TE::encryptWithAES( msg3, rawPublicKeys, metaA3 );
+
+    // Node B encrypts same 3 messages in same sequence
+    libBLS::EncryptMetaData metaB1, metaB2, metaB3;
+    metaB1.seed = seed;
+    metaB2.seed = seed;
+    metaB3.seed = seed;
+    auto cipherB1 = libBLS::TE::encryptWithAES( msg1, rawPublicKeys, metaB1 );
+    auto cipherB2 = libBLS::TE::encryptWithAES( msg2, rawPublicKeys, metaB2 );
+    auto cipherB3 = libBLS::TE::encryptWithAES( msg3, rawPublicKeys, metaB3 );
+
+    // All corresponding ciphertexts must match between nodes
+    BOOST_CHECK( cipherA1.ciphertext->toBytes() == cipherB1.ciphertext->toBytes() );
+    BOOST_CHECK( cipherA2.ciphertext->toBytes() == cipherB2.ciphertext->toBytes() );
+    BOOST_CHECK( cipherA3.ciphertext->toBytes() == cipherB3.ciphertext->toBytes() );
+
+    // Each ciphertext must be different (different messages)
+    BOOST_CHECK( cipherA1.ciphertext->toBytes() != cipherA2.ciphertext->toBytes() );
+    BOOST_CHECK( cipherA2.ciphertext->toBytes() != cipherA3.ciphertext->toBytes() );
+
+    // Random secrets are derived from seed, so with same seed they're the SAME
+    BOOST_CHECK( cipherA1.randomSecret == cipherA2.randomSecret );
+    BOOST_CHECK( cipherA2.randomSecret == cipherA3.randomSecret );
+    BOOST_CHECK( cipherA1.randomSecret == cipherB1.randomSecret );
+}
+
+// Seeded ciphertext can be decrypted correctly by any node
+BOOST_AUTO_TEST_CASE( TESeededEncryptionDecryptionFlow ) {
+    const size_t numAll = 4;
+    const size_t numSigned = 3;
+
+    keys keys = generateKeys( numSigned, numAll );
+    std::vector< uint8_t > message = randomByteVec( 100 );
+
+    std::array< uint8_t, libBLS::AES_256_KEY_SIZE_BYTES > seed{};
+    seed.fill( 0xEF );
+
+    // Encrypt with seed using high-level wrapper
+    libBLS::EncryptMetaData metaData;
+    metaData.seed = seed;
+    libBLS::Ciphertext ciphertext =
+        libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic, metaData );
+
+    // Prepare public key shares for validation
+    std::vector< libBLS::TEPublicKeyShare > publicKeyShares;
+    for ( size_t i = 0; i < numSigned; ++i ) {
+        publicKeyShares.emplace_back( libBLS::TEPublicKeyShare( keys.secretKeys[i] ) );
+    }
+
+    for ( const auto& cipheredKey : ciphertext.getKeys() ) {
+        // Validate the seeded encryption
+        libBLS::ThresholdEncryption::validateEncryption( cipheredKey, nullptr );
+
+        // Partial decrypt with each signer
+        libBLS::TEDecryptSet decryptSet( numSigned, numAll );
+        for ( size_t i = 0; i < numSigned; ++i ) {
+            libBLS::TEDecryptionShare decrShare =
+                libBLS::ThresholdEncryption::partialDecrypt( cipheredKey, keys.secretKeys[i] );
+            libBLS::ThresholdEncryption::validateDecryptionShare(
+                cipheredKey, decrShare, publicKeyShares[i], nullptr );
+            decryptSet.addDecryptShare( decrShare );
+        }
+
+        // Combine shares and decrypt
+        libBLS::AES256Key aesKey =
+            libBLS::ThresholdEncryption::combineShares( cipheredKey, decryptSet );
+
+        // Validate combined decryption
+        libBLS::ThresholdEncryption::validateCombinedDecryption(
+            ciphertext, aesKey, keys.commonPublic );
+
+        // Decrypt and verify message
+        std::vector< uint8_t > decryptedMessage =
+            libBLS::ThresholdEncryption::decrypt( ciphertext, aesKey, std::nullopt );
+        BOOST_REQUIRE( decryptedMessage == message );
+    }
+}
 
 BOOST_AUTO_TEST_CASE( TEProcessWithWrappers ) {
     for ( size_t i = 0; i < 10; i++ ) {

--- a/test/test_TE_wrappers.cpp
+++ b/test/test_TE_wrappers.cpp
@@ -438,10 +438,10 @@ BOOST_AUTO_TEST_CASE( TEEncryptDeterministicSeededKeyAndScalar ) {
     keys keys = generateKeys( numSigned, numAll );
     std::vector< uint8_t > message = randomByteVec( 100 );
 
-    std::array< uint8_t, libBLS::AES_256_KEY_SIZE_BYTES > seedA{};
-    std::array< uint8_t, libBLS::AES_256_KEY_SIZE_BYTES > seedB{};
-    seedA.fill( 0x42 );
-    seedB.fill( 0x43 );
+    libBLS::Seed256 seedA{};
+    libBLS::Seed256 seedB{};
+    seedA.data.fill( 0x42 );
+    seedB.data.fill( 0x43 );
 
     std::vector< libBLS::algebra::G2Point > rawPublicKeys = { keys.commonPublic.getPublicKeyRaw() };
 
@@ -508,8 +508,8 @@ BOOST_AUTO_TEST_CASE( TESeededCrossNodeDeterminism ) {
     std::vector< uint8_t > message = randomByteVec( 100 );
 
     // Fixed seed that both "nodes" will use
-    std::array< uint8_t, libBLS::AES_256_KEY_SIZE_BYTES > sharedSeed{};
-    sharedSeed.fill( 0xAB );
+    libBLS::Seed256 sharedSeed{};
+    sharedSeed.data.fill( 0xAB );
 
     std::vector< libBLS::algebra::G2Point > rawPublicKeys = { keys.commonPublic.getPublicKeyRaw() };
 
@@ -545,8 +545,8 @@ BOOST_AUTO_TEST_CASE( TESeededMultipleMessageSequence ) {
     std::vector< uint8_t > msg2 = randomByteVec( 75 );
     std::vector< uint8_t > msg3 = randomByteVec( 100 );
 
-    std::array< uint8_t, libBLS::AES_256_KEY_SIZE_BYTES > seed{};
-    seed.fill( 0xCD );
+    libBLS::Seed256 seed{};
+    seed.data.fill( 0xCD );
 
     std::vector< libBLS::algebra::G2Point > rawPublicKeys = { keys.commonPublic.getPublicKeyRaw() };
 
@@ -591,8 +591,8 @@ BOOST_AUTO_TEST_CASE( TESeededEncryptionDecryptionFlow ) {
     keys keys = generateKeys( numSigned, numAll );
     std::vector< uint8_t > message = randomByteVec( 100 );
 
-    std::array< uint8_t, libBLS::AES_256_KEY_SIZE_BYTES > seed{};
-    seed.fill( 0xEF );
+    libBLS::Seed256 seed{};
+    seed.data.fill( 0xEF );
 
     // Encrypt with seed using high-level wrapper
     libBLS::EncryptMetaData metaData;

--- a/test/test_encrypt_message.cpp
+++ b/test/test_encrypt_message.cpp
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
 
         // encrypt message using libBLS
         libBLS::TEPublicKey publicKey( pKeyStr, libBLS::Base::HEXA );
-        libBLS::ThresholdEncryption::EncryptMetaData metaData;
+        libBLS::EncryptMetaData metaData;
         metaData.associatedDataAesCbc = additionalAuthenticatedData;
         metaData.associatedDataTE = additionalAuthenticatedDataTE;
 
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE( EncryptMessage ) {
         for ( const auto& publicKey : publicKeysStr ) {
             commonPublicKeys.push_back( libBLS::TEPublicKey( publicKey, libBLS::Base::HEXA ) );
         }
-        libBLS::ThresholdEncryption::EncryptMetaData metaData;
+        libBLS::EncryptMetaData metaData;
         metaData.associatedDataAesCbc = additionalAuthenticatedData;
         metaData.associatedDataTE = additionalAuthenticatedDataTE;
         libBLS::Ciphertext ciphertext =

--- a/test/unit_tests_te.cpp
+++ b/test/unit_tests_te.cpp
@@ -21,12 +21,14 @@
   @date 2019
  */
 
+#include <algorithm>
+#include <optional>
 #include <random>
 
 #include "test/utils.h"
+#include "threshold_encryption/AesGcmCipher.h"
 #include <threshold_encryption.h>
 #include <tools/utils.h>
-#include <memory>
 
 #include <openssl/rand.h>
 
@@ -41,6 +43,139 @@ BOOST_TEST_GLOBAL_CONFIGURATION( GlobalConfig );
 
 BOOST_AUTO_TEST_SUITE( TestAES )
 
+// Test the default constructor generates a random key
+BOOST_AUTO_TEST_CASE( RandomKeyConstructor ) {
+    libBLS::ThresholdUtils::initRAND();
+
+    const std::string message = "Test message for random key constructor";
+    std::vector< uint8_t > messageBytes( message.begin(), message.end() );
+
+    // Create cipher with random key
+    libBLS::AesGcmCipher cipher;
+
+    // Encrypt and decrypt
+    auto ciphertext = cipher.encrypt( messageBytes );
+    auto decrypted = cipher.decrypt( ciphertext );
+
+    BOOST_REQUIRE( decrypted == messageBytes );
+
+    // Verify getKey() returns a non-zero key
+    const auto& key = cipher.getKey();
+    bool allZeros = std::all_of( key.begin(), key.end(), []( uint8_t b ) { return b == 0; } );
+    BOOST_REQUIRE( !allZeros );
+}
+
+// Test that two random ciphers produce different keys
+BOOST_AUTO_TEST_CASE( RandomKeyUniqueness ) {
+    libBLS::ThresholdUtils::initRAND();
+
+    libBLS::AesGcmCipher cipher1;
+    libBLS::AesGcmCipher cipher2;
+
+    // Two separate random ciphers should have different keys
+    BOOST_REQUIRE( cipher1.getKey() != cipher2.getKey() );
+}
+
+// Test seeded constructor produces deterministic key
+BOOST_AUTO_TEST_CASE( SeededKeyDeterminism ) {
+    libBLS::ThresholdUtils::initRAND();
+
+    // Create a fixed seed
+    std::array< uint8_t, libBLS::AES_256_KEY_SIZE_BYTES > seed;
+    RAND_bytes( seed.data(), seed.size() );
+
+    // Create two ciphers with the same seed
+    libBLS::AesGcmCipher cipher1{ seed };
+    libBLS::AesGcmCipher cipher2{ seed };
+
+    // Both should produce the same key
+    BOOST_REQUIRE( cipher1.getKey() == cipher2.getKey() );
+}
+
+// Test seeded constructor - same seed produces same ciphertext for same plaintext sequence
+BOOST_AUTO_TEST_CASE( SeededEncryptionDeterminism ) {
+    libBLS::ThresholdUtils::initRAND();
+
+    // Create a fixed seed
+    std::array< uint8_t, libBLS::AES_256_KEY_SIZE_BYTES > seed;
+    RAND_bytes( seed.data(), seed.size() );
+
+    const std::string message1 = "First message";
+    const std::string message2 = "Second message";
+    std::vector< uint8_t > msg1Bytes( message1.begin(), message1.end() );
+    std::vector< uint8_t > msg2Bytes( message2.begin(), message2.end() );
+
+    // Simulate two nodes with same seed
+    libBLS::AesGcmCipher node1Cipher{ seed };
+    libBLS::AesGcmCipher node2Cipher{ seed };
+
+    // Encrypt same messages in same order
+    auto ct1_node1 = node1Cipher.encrypt( msg1Bytes );
+    auto ct2_node1 = node1Cipher.encrypt( msg2Bytes );
+
+    auto ct1_node2 = node2Cipher.encrypt( msg1Bytes );
+    auto ct2_node2 = node2Cipher.encrypt( msg2Bytes );
+
+    // Both nodes should produce identical ciphertexts
+    BOOST_REQUIRE( ct1_node1 == ct1_node2 );
+    BOOST_REQUIRE( ct2_node1 == ct2_node2 );
+
+    // Verify same message encrypted again produces DIFFERENT ciphertext (counter incremented)
+    auto ct3_node1 = node1Cipher.encrypt( msg1Bytes );
+    BOOST_REQUIRE( ct1_node1 != ct3_node1 );
+}
+
+// Test that different seeds produce different keys
+BOOST_AUTO_TEST_CASE( DifferentSeedsDifferentKeys ) {
+    libBLS::ThresholdUtils::initRAND();
+
+    std::array< uint8_t, libBLS::AES_256_KEY_SIZE_BYTES > seed1;
+    std::array< uint8_t, libBLS::AES_256_KEY_SIZE_BYTES > seed2;
+    RAND_bytes( seed1.data(), seed1.size() );
+    RAND_bytes( seed2.data(), seed2.size() );
+
+    libBLS::AesGcmCipher cipher1{ seed1 };
+    libBLS::AesGcmCipher cipher2{ seed2 };
+
+    BOOST_REQUIRE( cipher1.getKey() != cipher2.getKey() );
+}
+
+// Test raw key constructor
+BOOST_AUTO_TEST_CASE( RawKeyConstructor ) {
+    libBLS::ThresholdUtils::initRAND();
+
+    // Generate a key manually
+    libBLS::AES256Key rawKey;
+    RAND_bytes( rawKey.data(), rawKey.size() );
+
+    // Create cipher with raw key
+    libBLS::AesGcmCipher cipher{ rawKey, libBLS::KeyType::Raw };
+
+    // Verify getKey() returns the same key
+    BOOST_REQUIRE( cipher.getKey() == rawKey );
+}
+
+// Test raw key constructor - encrypt/decrypt round trip
+BOOST_AUTO_TEST_CASE( RawKeyRoundTrip ) {
+    libBLS::ThresholdUtils::initRAND();
+
+    libBLS::AES256Key rawKey;
+    RAND_bytes( rawKey.data(), rawKey.size() );
+
+    const std::string message = "Test message for raw key round trip";
+    std::vector< uint8_t > messageBytes( message.begin(), message.end() );
+
+    // Encrypt with one instance
+    libBLS::AesGcmCipher encryptor{ rawKey, libBLS::KeyType::Raw };
+    auto ciphertext = encryptor.encrypt( messageBytes );
+
+    // Decrypt with a new instance using same key
+    libBLS::AesGcmCipher decryptor{ rawKey, libBLS::KeyType::Raw };
+    auto decrypted = decryptor.decrypt( ciphertext );
+
+    BOOST_REQUIRE( decrypted == messageBytes );
+}
+
 BOOST_AUTO_TEST_CASE( SimpleAES ) {
     libBLS::ThresholdUtils::initRAND();
     unsigned char keyBytes[32];
@@ -51,7 +186,7 @@ BOOST_AUTO_TEST_CASE( SimpleAES ) {
     const std::string message = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     std::vector< uint8_t > messageBytes( message.begin(), message.end() );
 
-    libBLS::AesGcmCipher cipher{ randomAesKey };
+    libBLS::AesGcmCipher cipher{ randomAesKey, libBLS::KeyType::Raw };
     auto ciphertext = cipher.encrypt( messageBytes );
     auto decryptedText = cipher.decrypt( ciphertext );
 
@@ -70,7 +205,7 @@ BOOST_AUTO_TEST_CASE( wrongCiphertext ) {
         "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
     std::vector< uint8_t > badMessageBytes( badMessage.begin(), badMessage.end() );
 
-    libBLS::AesGcmCipher cipher{ randomAesKey };
+    libBLS::AesGcmCipher cipher{ randomAesKey, libBLS::KeyType::Raw };
     auto bad_ciphertext = cipher.encrypt( badMessageBytes );
 
     auto decryptedText = cipher.decrypt( bad_ciphertext );
@@ -89,7 +224,7 @@ BOOST_AUTO_TEST_CASE( wrongKey ) {
     const std::string message = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     std::vector< uint8_t > messageBytes( message.begin(), message.end() );
 
-    libBLS::AesGcmCipher cipher{ randomAesKey };
+    libBLS::AesGcmCipher cipher{ randomAesKey, libBLS::KeyType::Raw };
     auto ciphertext = cipher.encrypt( messageBytes );
 
     unsigned char bad_keyBytes[32];
@@ -98,7 +233,7 @@ BOOST_AUTO_TEST_CASE( wrongKey ) {
     std::copy(
         bad_keyBytes, bad_keyBytes + libBLS::AES_256_KEY_SIZE_BYTES, randomBadAesKey.begin() );
 
-    libBLS::AesGcmCipher bad_cipher{ randomBadAesKey };
+    libBLS::AesGcmCipher bad_cipher{ randomBadAesKey, libBLS::KeyType::Raw };
     BOOST_REQUIRE_THROW( bad_cipher.decrypt( ciphertext ), std::runtime_error );
 }
 
@@ -113,7 +248,7 @@ BOOST_AUTO_TEST_CASE( AESWithAAD ) {
     // Create AAD (additional authenticated data)
     std::vector< uint8_t > aad = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
 
-    libBLS::AesGcmCipher cipher{ randomAesKey };
+    libBLS::AesGcmCipher cipher{ randomAesKey, libBLS::KeyType::Raw };
 
     // Encrypt with AAD
     auto ciphertext = cipher.encrypt( messageBytes, aad );
@@ -136,7 +271,7 @@ BOOST_AUTO_TEST_CASE( AESWithWrongAAD ) {
     // Different AAD
     std::vector< uint8_t > wrong_aad = { 0xFF, 0xFE, 0xFD, 0xFC };
 
-    libBLS::AesGcmCipher cipher{ randomAesKey };
+    libBLS::AesGcmCipher cipher{ randomAesKey, libBLS::KeyType::Raw };
 
     // Encrypt with AAD
     auto ciphertext = cipher.encrypt( messageBytes, aad );
@@ -156,7 +291,7 @@ BOOST_AUTO_TEST_CASE( AESWithMissingAAD ) {
     // Create AAD
     std::vector< uint8_t > aad = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
 
-    libBLS::AesGcmCipher cipher{ randomAesKey };
+    libBLS::AesGcmCipher cipher{ randomAesKey, libBLS::KeyType::Raw };
 
     // Encrypt with AAD
     auto ciphertext = cipher.encrypt( messageBytes, aad );
@@ -173,7 +308,7 @@ BOOST_AUTO_TEST_CASE( AESWithoutAAD_BackwardCompatibility ) {
     const std::string message = "Hello, this is a test message without AAD!";
     std::vector< uint8_t > messageBytes( message.begin(), message.end() );
 
-    libBLS::AesGcmCipher cipher{ randomAesKey };
+    libBLS::AesGcmCipher cipher{ randomAesKey, libBLS::KeyType::Raw };
 
     // Encrypt without AAD (backward compatible)
     auto ciphertext = cipher.encrypt( messageBytes );
@@ -199,7 +334,7 @@ BOOST_AUTO_TEST_CASE( AESWithEmptyAAD ) {
     // Empty AAD (different from nullopt)
     std::vector< uint8_t > empty_aad = {};
 
-    libBLS::AesGcmCipher cipher{ randomAesKey };
+    libBLS::AesGcmCipher cipher{ randomAesKey, libBLS::KeyType::Raw };
 
     // Encrypt with empty AAD
     auto ciphertext = cipher.encrypt( messageBytes, empty_aad );
@@ -363,7 +498,7 @@ BOOST_AUTO_TEST_CASE( SimpleEncryption ) {
 
     libBLS::algebra::G2Point publicKey = secretKey * libBLS::algebra::G2Point::generator();
 
-    auto result = te_instance.getCiphertext( randomAesKey, publicKey );
+    auto result = te_instance.getCiphertext( randomAesKey, publicKey, std::nullopt, std::nullopt );
 
     // one decrypt share at a time
     for ( const auto& cipheredKey : result.ciphertext ) {
@@ -417,7 +552,7 @@ BOOST_AUTO_TEST_CASE( SimpleEncryptionWithAES ) {
 
         libBLS::AES256Key decryptedAesKey = te_instance.CombineShares( cipheredKey, shares );
 
-        libBLS::AesGcmCipher aesGcmCipher{ decryptedAesKey };
+        libBLS::AesGcmCipher aesGcmCipher{ decryptedAesKey, libBLS::KeyType::Raw };
         std::vector< uint8_t > plaintext = aesGcmCipher.decrypt( encryptedMessage );
 
         // append random secret to end of original message
@@ -440,9 +575,12 @@ BOOST_AUTO_TEST_CASE( EncryptionWithAES_AAD ) {
     libBLS::algebra::FrScalar secretKey = libBLS::algebra::FrScalar::random();
     libBLS::algebra::G2Point publicKey = secretKey * libBLS::algebra::G2Point::generator();
 
+    libBLS::EncryptMetaData encryptMeta;
+    encryptMeta.associatedDataAesCbc = aad;
+
     // Encrypt with AAD
     libBLS::CipherResult ciphertextWithAes =
-        te_instance.encryptWithAES( messageBytes, publicKey, aad );
+        te_instance.encryptWithAES( messageBytes, publicKey, encryptMeta );
 
     auto encryptedMessage = ciphertextWithAes.ciphertext->getData();
 
@@ -458,7 +596,7 @@ BOOST_AUTO_TEST_CASE( EncryptionWithAES_AAD ) {
         libBLS::AES256Key decryptedAesKey = te_instance.CombineShares( cipheredKey, shares );
 
         // Decrypt with the same AAD - should succeed
-        libBLS::AesGcmCipher aesGcmCipher{ decryptedAesKey };
+        libBLS::AesGcmCipher aesGcmCipher{ decryptedAesKey, libBLS::KeyType::Raw };
         std::vector< uint8_t > plaintext = aesGcmCipher.decrypt( encryptedMessage, aad );
 
         // Append random secret to end of original message for comparison
@@ -484,9 +622,12 @@ BOOST_AUTO_TEST_CASE( EncryptionWithAES_WrongAAD ) {
     libBLS::algebra::FrScalar secretKey = libBLS::algebra::FrScalar::random();
     libBLS::algebra::G2Point publicKey = secretKey * libBLS::algebra::G2Point::generator();
 
+    libBLS::EncryptMetaData encryptMeta;
+    encryptMeta.associatedDataAesCbc = aad;
+
     // Encrypt with AAD
     libBLS::CipherResult ciphertextWithAes =
-        te_instance.encryptWithAES( messageBytes, publicKey, aad );
+        te_instance.encryptWithAES( messageBytes, publicKey, encryptMeta );
 
     auto encryptedMessage = ciphertextWithAes.ciphertext->getData();
 
@@ -500,7 +641,7 @@ BOOST_AUTO_TEST_CASE( EncryptionWithAES_WrongAAD ) {
         libBLS::AES256Key decryptedAesKey = te_instance.CombineShares( cipheredKey, shares );
 
         // Decrypt with wrong AAD - should fail
-        libBLS::AesGcmCipher aesGcmCipher{ decryptedAesKey };
+        libBLS::AesGcmCipher aesGcmCipher{ decryptedAesKey, libBLS::KeyType::Raw };
         BOOST_REQUIRE_THROW(
             aesGcmCipher.decrypt( encryptedMessage, wrong_aad ), std::runtime_error );
 
@@ -536,7 +677,7 @@ BOOST_AUTO_TEST_CASE( encryptionWithAESWrongKey ) {
         RAND_bytes( randomAesKey.data(), randomAesKey.size() );
 
 
-        libBLS::AesGcmCipher cipher{ randomAesKey };
+        libBLS::AesGcmCipher cipher{ randomAesKey, libBLS::KeyType::Raw };
         BOOST_REQUIRE_THROW( cipher.decrypt( encryptedMessage ), std::runtime_error );
     }
 }
@@ -568,7 +709,7 @@ BOOST_AUTO_TEST_CASE( encryptionWithAESWrongCiphertext ) {
         auto bad_encryptedMessage =
             te_instance.encryptWithAES( badMessageBytes, publicKey ).ciphertext->getData();
 
-        libBLS::AesGcmCipher cipher{ decryptedAesKey };
+        libBLS::AesGcmCipher cipher{ decryptedAesKey, libBLS::KeyType::Raw };
         BOOST_REQUIRE_THROW( cipher.decrypt( bad_encryptedMessage ), std::runtime_error );
     }
 }
@@ -604,7 +745,7 @@ BOOST_AUTO_TEST_CASE( EncryptionCipherToBytes ) {
 
         libBLS::AES256Key decryptedAesKey = te_instance.CombineShares( cipheredkey, shares );
 
-        libBLS::AesGcmCipher cipher{ decryptedAesKey };
+        libBLS::AesGcmCipher cipher{ decryptedAesKey, libBLS::KeyType::Raw };
         std::vector< uint8_t > plaintext = cipher.decrypt( encryptedMessage );
 
         // append random secret to the message
@@ -652,7 +793,7 @@ BOOST_AUTO_TEST_CASE( ThresholdEncryptionReal ) {
     libBLS::AES256Key key;
     RAND_bytes( key.data(), key.size() );
 
-    auto result = obj.getCiphertext( key, commonPublic );
+    auto result = obj.getCiphertext( key, commonPublic, std::nullopt, std::nullopt );
 
     for ( const auto& cipheredKey : result.ciphertext ) {
         std::vector< std::pair< libBLS::algebra::G2Point, size_t > > shares( t );
@@ -732,7 +873,7 @@ BOOST_AUTO_TEST_CASE( ThresholdEncryptionRandomPK ) {
     libBLS::AES256Key key;
     RAND_bytes( key.data(), key.size() );
 
-    auto result = obj.getCiphertext( key, commonPublic );
+    auto result = obj.getCiphertext( key, commonPublic, std::nullopt, std::nullopt );
 
     std::vector< std::pair< libBLS::algebra::G2Point, size_t > > shares( 11 );
 
@@ -798,7 +939,7 @@ BOOST_AUTO_TEST_CASE( ThresholdEncryptionRandomSK ) {
     libBLS::AES256Key key;
     RAND_bytes( key.data(), key.size() );
 
-    auto result = obj.getCiphertext( key, commonPublic );
+    auto result = obj.getCiphertext( key, commonPublic, std::nullopt, std::nullopt );
 
     for ( const auto& cipheredKey : result.ciphertext ) {
         std::vector< std::pair< libBLS::algebra::G2Point, size_t > > shares( 11 );
@@ -858,7 +999,7 @@ BOOST_AUTO_TEST_CASE( ThresholdEncryptionCorruptedCiphertext ) {
     libBLS::AES256Key key;
     RAND_bytes( key.data(), key.size() );
 
-    auto result = obj.getCiphertext( key, commonPublic );
+    auto result = obj.getCiphertext( key, commonPublic, std::nullopt, std::nullopt );
 
     libBLS::algebra::G1Point rand = libBLS::algebra::G1Point::random();
 

--- a/test/unit_tests_te.cpp
+++ b/test/unit_tests_te.cpp
@@ -81,8 +81,8 @@ BOOST_AUTO_TEST_CASE( SeededKeyDeterminism ) {
     libBLS::ThresholdUtils::initRAND();
 
     // Create a fixed seed
-    std::array< uint8_t, libBLS::AES_256_KEY_SIZE_BYTES > seed;
-    RAND_bytes( seed.data(), seed.size() );
+    libBLS::Seed256 seed;
+    RAND_bytes( seed.data.data(), seed.data.size() );
 
     // Create two ciphers with the same seed
     libBLS::AesGcmCipher cipher1{ seed };
@@ -97,8 +97,8 @@ BOOST_AUTO_TEST_CASE( SeededEncryptionDeterminism ) {
     libBLS::ThresholdUtils::initRAND();
 
     // Create a fixed seed
-    std::array< uint8_t, libBLS::AES_256_KEY_SIZE_BYTES > seed;
-    RAND_bytes( seed.data(), seed.size() );
+    libBLS::Seed256 seed;
+    RAND_bytes( seed.data.data(), seed.data.size() );
 
     const std::string message1 = "First message";
     const std::string message2 = "Second message";
@@ -129,10 +129,10 @@ BOOST_AUTO_TEST_CASE( SeededEncryptionDeterminism ) {
 BOOST_AUTO_TEST_CASE( DifferentSeedsDifferentKeys ) {
     libBLS::ThresholdUtils::initRAND();
 
-    std::array< uint8_t, libBLS::AES_256_KEY_SIZE_BYTES > seed1;
-    std::array< uint8_t, libBLS::AES_256_KEY_SIZE_BYTES > seed2;
-    RAND_bytes( seed1.data(), seed1.size() );
-    RAND_bytes( seed2.data(), seed2.size() );
+    libBLS::Seed256 seed1;
+    libBLS::Seed256 seed2;
+    RAND_bytes( seed1.data.data(), seed1.data.size() );
+    RAND_bytes( seed2.data.data(), seed2.data.size() );
 
     libBLS::AesGcmCipher cipher1{ seed1 };
     libBLS::AesGcmCipher cipher2{ seed2 };
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE( RawKeyConstructor ) {
     RAND_bytes( rawKey.data(), rawKey.size() );
 
     // Create cipher with raw key
-    libBLS::AesGcmCipher cipher{ rawKey, libBLS::KeyType::Raw };
+    libBLS::AesGcmCipher cipher{ rawKey };
 
     // Verify getKey() returns the same key
     BOOST_REQUIRE( cipher.getKey() == rawKey );
@@ -166,11 +166,11 @@ BOOST_AUTO_TEST_CASE( RawKeyRoundTrip ) {
     std::vector< uint8_t > messageBytes( message.begin(), message.end() );
 
     // Encrypt with one instance
-    libBLS::AesGcmCipher encryptor{ rawKey, libBLS::KeyType::Raw };
+    libBLS::AesGcmCipher encryptor{ rawKey };
     auto ciphertext = encryptor.encrypt( messageBytes );
 
     // Decrypt with a new instance using same key
-    libBLS::AesGcmCipher decryptor{ rawKey, libBLS::KeyType::Raw };
+    libBLS::AesGcmCipher decryptor{ rawKey };
     auto decrypted = decryptor.decrypt( ciphertext );
 
     BOOST_REQUIRE( decrypted == messageBytes );
@@ -186,7 +186,7 @@ BOOST_AUTO_TEST_CASE( SimpleAES ) {
     const std::string message = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     std::vector< uint8_t > messageBytes( message.begin(), message.end() );
 
-    libBLS::AesGcmCipher cipher{ randomAesKey, libBLS::KeyType::Raw };
+    libBLS::AesGcmCipher cipher{ randomAesKey };
     auto ciphertext = cipher.encrypt( messageBytes );
     auto decryptedText = cipher.decrypt( ciphertext );
 
@@ -205,7 +205,7 @@ BOOST_AUTO_TEST_CASE( wrongCiphertext ) {
         "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
     std::vector< uint8_t > badMessageBytes( badMessage.begin(), badMessage.end() );
 
-    libBLS::AesGcmCipher cipher{ randomAesKey, libBLS::KeyType::Raw };
+    libBLS::AesGcmCipher cipher{ randomAesKey };
     auto bad_ciphertext = cipher.encrypt( badMessageBytes );
 
     auto decryptedText = cipher.decrypt( bad_ciphertext );
@@ -224,7 +224,7 @@ BOOST_AUTO_TEST_CASE( wrongKey ) {
     const std::string message = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     std::vector< uint8_t > messageBytes( message.begin(), message.end() );
 
-    libBLS::AesGcmCipher cipher{ randomAesKey, libBLS::KeyType::Raw };
+    libBLS::AesGcmCipher cipher{ randomAesKey };
     auto ciphertext = cipher.encrypt( messageBytes );
 
     unsigned char bad_keyBytes[32];
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE( wrongKey ) {
     std::copy(
         bad_keyBytes, bad_keyBytes + libBLS::AES_256_KEY_SIZE_BYTES, randomBadAesKey.begin() );
 
-    libBLS::AesGcmCipher bad_cipher{ randomBadAesKey, libBLS::KeyType::Raw };
+    libBLS::AesGcmCipher bad_cipher{ randomBadAesKey };
     BOOST_REQUIRE_THROW( bad_cipher.decrypt( ciphertext ), std::runtime_error );
 }
 
@@ -248,7 +248,7 @@ BOOST_AUTO_TEST_CASE( AESWithAAD ) {
     // Create AAD (additional authenticated data)
     std::vector< uint8_t > aad = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
 
-    libBLS::AesGcmCipher cipher{ randomAesKey, libBLS::KeyType::Raw };
+    libBLS::AesGcmCipher cipher{ randomAesKey };
 
     // Encrypt with AAD
     auto ciphertext = cipher.encrypt( messageBytes, aad );
@@ -271,7 +271,7 @@ BOOST_AUTO_TEST_CASE( AESWithWrongAAD ) {
     // Different AAD
     std::vector< uint8_t > wrong_aad = { 0xFF, 0xFE, 0xFD, 0xFC };
 
-    libBLS::AesGcmCipher cipher{ randomAesKey, libBLS::KeyType::Raw };
+    libBLS::AesGcmCipher cipher{ randomAesKey };
 
     // Encrypt with AAD
     auto ciphertext = cipher.encrypt( messageBytes, aad );
@@ -291,7 +291,7 @@ BOOST_AUTO_TEST_CASE( AESWithMissingAAD ) {
     // Create AAD
     std::vector< uint8_t > aad = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
 
-    libBLS::AesGcmCipher cipher{ randomAesKey, libBLS::KeyType::Raw };
+    libBLS::AesGcmCipher cipher{ randomAesKey };
 
     // Encrypt with AAD
     auto ciphertext = cipher.encrypt( messageBytes, aad );
@@ -308,7 +308,7 @@ BOOST_AUTO_TEST_CASE( AESWithoutAAD_BackwardCompatibility ) {
     const std::string message = "Hello, this is a test message without AAD!";
     std::vector< uint8_t > messageBytes( message.begin(), message.end() );
 
-    libBLS::AesGcmCipher cipher{ randomAesKey, libBLS::KeyType::Raw };
+    libBLS::AesGcmCipher cipher{ randomAesKey };
 
     // Encrypt without AAD (backward compatible)
     auto ciphertext = cipher.encrypt( messageBytes );
@@ -334,7 +334,7 @@ BOOST_AUTO_TEST_CASE( AESWithEmptyAAD ) {
     // Empty AAD (different from nullopt)
     std::vector< uint8_t > empty_aad = {};
 
-    libBLS::AesGcmCipher cipher{ randomAesKey, libBLS::KeyType::Raw };
+    libBLS::AesGcmCipher cipher{ randomAesKey };
 
     // Encrypt with empty AAD
     auto ciphertext = cipher.encrypt( messageBytes, empty_aad );
@@ -552,7 +552,7 @@ BOOST_AUTO_TEST_CASE( SimpleEncryptionWithAES ) {
 
         libBLS::AES256Key decryptedAesKey = te_instance.CombineShares( cipheredKey, shares );
 
-        libBLS::AesGcmCipher aesGcmCipher{ decryptedAesKey, libBLS::KeyType::Raw };
+        libBLS::AesGcmCipher aesGcmCipher{ decryptedAesKey };
         std::vector< uint8_t > plaintext = aesGcmCipher.decrypt( encryptedMessage );
 
         // append random secret to end of original message
@@ -596,7 +596,7 @@ BOOST_AUTO_TEST_CASE( EncryptionWithAES_AAD ) {
         libBLS::AES256Key decryptedAesKey = te_instance.CombineShares( cipheredKey, shares );
 
         // Decrypt with the same AAD - should succeed
-        libBLS::AesGcmCipher aesGcmCipher{ decryptedAesKey, libBLS::KeyType::Raw };
+        libBLS::AesGcmCipher aesGcmCipher{ decryptedAesKey };
         std::vector< uint8_t > plaintext = aesGcmCipher.decrypt( encryptedMessage, aad );
 
         // Append random secret to end of original message for comparison
@@ -641,7 +641,7 @@ BOOST_AUTO_TEST_CASE( EncryptionWithAES_WrongAAD ) {
         libBLS::AES256Key decryptedAesKey = te_instance.CombineShares( cipheredKey, shares );
 
         // Decrypt with wrong AAD - should fail
-        libBLS::AesGcmCipher aesGcmCipher{ decryptedAesKey, libBLS::KeyType::Raw };
+        libBLS::AesGcmCipher aesGcmCipher{ decryptedAesKey };
         BOOST_REQUIRE_THROW(
             aesGcmCipher.decrypt( encryptedMessage, wrong_aad ), std::runtime_error );
 
@@ -677,7 +677,7 @@ BOOST_AUTO_TEST_CASE( encryptionWithAESWrongKey ) {
         RAND_bytes( randomAesKey.data(), randomAesKey.size() );
 
 
-        libBLS::AesGcmCipher cipher{ randomAesKey, libBLS::KeyType::Raw };
+        libBLS::AesGcmCipher cipher{ randomAesKey };
         BOOST_REQUIRE_THROW( cipher.decrypt( encryptedMessage ), std::runtime_error );
     }
 }
@@ -709,7 +709,7 @@ BOOST_AUTO_TEST_CASE( encryptionWithAESWrongCiphertext ) {
         auto bad_encryptedMessage =
             te_instance.encryptWithAES( badMessageBytes, publicKey ).ciphertext->getData();
 
-        libBLS::AesGcmCipher cipher{ decryptedAesKey, libBLS::KeyType::Raw };
+        libBLS::AesGcmCipher cipher{ decryptedAesKey };
         BOOST_REQUIRE_THROW( cipher.decrypt( bad_encryptedMessage ), std::runtime_error );
     }
 }
@@ -745,7 +745,7 @@ BOOST_AUTO_TEST_CASE( EncryptionCipherToBytes ) {
 
         libBLS::AES256Key decryptedAesKey = te_instance.CombineShares( cipheredkey, shares );
 
-        libBLS::AesGcmCipher cipher{ decryptedAesKey, libBLS::KeyType::Raw };
+        libBLS::AesGcmCipher cipher{ decryptedAesKey };
         std::vector< uint8_t > plaintext = cipher.decrypt( encryptedMessage );
 
         // append random secret to the message

--- a/threshold_encryption/AesGcmCipher.cpp
+++ b/threshold_encryption/AesGcmCipher.cpp
@@ -39,7 +39,7 @@ AesGcmCipher::AesGcmCipher() : isDeterministic( false ), encryptCounter( 0 ) {
     iv.fill( 0 );
 }
 
-AesGcmCipher::AesGcmCipher( const AES256Key& rawKey, KeyType )
+AesGcmCipher::AesGcmCipher( const AES256Key& rawKey )
     : key( rawKey ), isDeterministic( false ), encryptCounter( 0 ) {
     initAES();
     // IV will be generated randomly on each encrypt() call (or extracted from ciphertext for
@@ -47,8 +47,7 @@ AesGcmCipher::AesGcmCipher( const AES256Key& rawKey, KeyType )
     iv.fill( 0 );
 }
 
-AesGcmCipher::AesGcmCipher( const std::array< uint8_t, AES_256_KEY_SIZE_BYTES >& seed )
-    : isDeterministic( true ), encryptCounter( 0 ) {
+AesGcmCipher::AesGcmCipher( const Seed256& seed ) : isDeterministic( true ), encryptCounter( 0 ) {
     initAES();
 
     // Use HKDF to derive key deterministically from seed
@@ -78,7 +77,7 @@ AesGcmCipher::AesGcmCipher( const std::array< uint8_t, AES_256_KEY_SIZE_BYTES >&
     if ( EVP_PKEY_CTX_set1_hkdf_salt( pctx, salt, sizeof( salt ) - 1 ) <= 0 ) {
         throw std::runtime_error( "Failed to set HKDF salt" );
     }
-    if ( EVP_PKEY_CTX_set1_hkdf_key( pctx, seed.data(), seed.size() ) <= 0 ) {
+    if ( EVP_PKEY_CTX_set1_hkdf_key( pctx, seed.data.data(), seed.data.size() ) <= 0 ) {
         throw std::runtime_error( "Failed to set HKDF key" );
     }
     // Info parameter for domain separation - only deriving the encryption key

--- a/threshold_encryption/AesGcmCipher.cpp
+++ b/threshold_encryption/AesGcmCipher.cpp
@@ -117,9 +117,11 @@ std::vector< uint8_t > AesGcmCipher::encrypt(
         unsigned int hmacLen = 0;
 
         // Create input: plaintext || counter (8 bytes, big-endian)
+        // Append counter as 8 bytes in big-endian order
         std::vector< uint8_t > hmacInput( plaintext.begin(), plaintext.end() );
-        for ( int i = 7; i >= 0; --i ) {
-            hmacInput.push_back( static_cast< uint8_t >( ( encryptCounter >> ( i * 8 ) ) & 0xFF ) );
+        for ( int byteIndex = 7; byteIndex >= 0; --byteIndex ) {
+            hmacInput.push_back(
+                static_cast< uint8_t >( ( encryptCounter >> ( byteIndex * 8 ) ) & 0xFF ) );
         }
 
         if ( !HMAC( EVP_sha256(), key.data(), key.size(), hmacInput.data(), hmacInput.size(),

--- a/threshold_encryption/AesGcmCipher.cpp
+++ b/threshold_encryption/AesGcmCipher.cpp
@@ -23,9 +23,78 @@
 
 #include "threshold_encryption/AesGcmCipher.h"
 #include "tools/utils.h"
+#include <openssl/hmac.h>
+#include <openssl/kdf.h>
 #include <mutex>
 
 namespace libBLS {
+
+AesGcmCipher::AesGcmCipher() : isDeterministic( false ), encryptCounter( 0 ) {
+    initAES();
+    // Generate random key
+    if ( RAND_bytes( key.data(), key.size() ) != 1 ) {
+        throw std::runtime_error( "Failed to generate random key" );
+    }
+    // IV will be generated randomly on each encrypt() call
+    iv.fill( 0 );
+}
+
+AesGcmCipher::AesGcmCipher( const AES256Key& rawKey, KeyType )
+    : key( rawKey ), isDeterministic( false ), encryptCounter( 0 ) {
+    initAES();
+    // IV will be generated randomly on each encrypt() call (or extracted from ciphertext for
+    // decrypt)
+    iv.fill( 0 );
+}
+
+AesGcmCipher::AesGcmCipher( const std::array< uint8_t, AES_256_KEY_SIZE_BYTES >& seed )
+    : isDeterministic( true ), encryptCounter( 0 ) {
+    initAES();
+
+    // Use HKDF to derive key deterministically from seed
+    // IV will be derived per-encryption using Synthetic IV (HMAC of plaintext)
+    EVP_PKEY_CTX* pctx = EVP_PKEY_CTX_new_id( EVP_PKEY_HKDF, nullptr );
+    if ( !pctx ) {
+        throw std::runtime_error( "Failed to create HKDF context" );
+    }
+
+    // Using a scope guard pattern for cleanup
+    struct CtxGuard {
+        EVP_PKEY_CTX* ctx;
+        ~CtxGuard() {
+            if ( ctx )
+                EVP_PKEY_CTX_free( ctx );
+        }
+    } guard{ pctx };
+
+    if ( EVP_PKEY_derive_init( pctx ) <= 0 ) {
+        throw std::runtime_error( "Failed to initialize HKDF" );
+    }
+    if ( EVP_PKEY_CTX_set_hkdf_md( pctx, EVP_sha256() ) <= 0 ) {
+        throw std::runtime_error( "Failed to set HKDF hash" );
+    }
+    // Salt is optional but recommended - using a fixed salt for determinism
+    static const unsigned char salt[] = "AesGcmCipher-v1";
+    if ( EVP_PKEY_CTX_set1_hkdf_salt( pctx, salt, sizeof( salt ) - 1 ) <= 0 ) {
+        throw std::runtime_error( "Failed to set HKDF salt" );
+    }
+    if ( EVP_PKEY_CTX_set1_hkdf_key( pctx, seed.data(), seed.size() ) <= 0 ) {
+        throw std::runtime_error( "Failed to set HKDF key" );
+    }
+    // Info parameter for domain separation - only deriving the encryption key
+    static const unsigned char info[] = "encryption-key";
+    if ( EVP_PKEY_CTX_add1_hkdf_info( pctx, info, sizeof( info ) - 1 ) <= 0 ) {
+        throw std::runtime_error( "Failed to set HKDF info" );
+    }
+
+    size_t outlen = AES_256_KEY_SIZE_BYTES;
+    if ( EVP_PKEY_derive( pctx, key.data(), &outlen ) <= 0 || outlen != AES_256_KEY_SIZE_BYTES ) {
+        throw std::runtime_error( "Failed to derive key material" );
+    }
+
+    // IV is not stored - it will be derived per-encryption from plaintext
+    iv.fill( 0 );
+}
 
 std::vector< uint8_t > AesGcmCipher::encrypt(
     const std::vector< uint8_t >& plaintext, const std::optional< std::vector< uint8_t > >& aad ) {
@@ -37,11 +106,33 @@ std::vector< uint8_t > AesGcmCipher::encrypt(
     std::vector< unsigned char > output;
     output.resize( enc_length, '\0' );
 
-    // Initialize IV vector
-    unsigned char iv[AES_GCM_IV_SIZE];
-    RAND_bytes( iv, AES_GCM_IV_SIZE );
+    // Compute IV: Synthetic IV (HMAC of plaintext + counter) for deterministic mode, random
+    // otherwise
+    unsigned char localIv[AES_GCM_IV_SIZE];
+    if ( isDeterministic ) {
+        // Synthetic IV: HMAC-SHA256(key, plaintext || counter) truncated to 12 bytes
+        // Counter ensures same plaintext encrypted multiple times gets different IVs
+        // As long as encrypt() is called in the same order, they produce identical output
+        unsigned char hmacResult[32];
+        unsigned int hmacLen = 0;
+
+        // Create input: plaintext || counter (8 bytes, big-endian)
+        std::vector< uint8_t > hmacInput( plaintext.begin(), plaintext.end() );
+        for ( int i = 7; i >= 0; --i ) {
+            hmacInput.push_back( static_cast< uint8_t >( ( encryptCounter >> ( i * 8 ) ) & 0xFF ) );
+        }
+
+        if ( !HMAC( EVP_sha256(), key.data(), key.size(), hmacInput.data(), hmacInput.size(),
+                 hmacResult, &hmacLen ) ) {
+            throw std::runtime_error( "Failed to compute synthetic IV" );
+        }
+        std::copy( hmacResult, hmacResult + AES_GCM_IV_SIZE, localIv );
+        ++encryptCounter;
+    } else {
+        RAND_bytes( localIv, AES_GCM_IV_SIZE );
+    }
     // Place IV at start of output
-    std::copy( iv, iv + AES_GCM_IV_SIZE, output.begin() );
+    std::copy( localIv, localIv + AES_GCM_IV_SIZE, output.begin() );
 
     // Account offset for the IV already stored in output vec
     size_t offset = AES_GCM_IV_SIZE;
@@ -59,7 +150,7 @@ std::vector< uint8_t > AesGcmCipher::encrypt(
     check( EVP_CIPHER_CTX_ctrl( e_ctx.get(), EVP_CTRL_GCM_SET_IVLEN, AES_GCM_IV_SIZE, nullptr ),
         "Failed to set IV length" );
     // now actually supply key & IV:
-    check( EVP_EncryptInit_ex( e_ctx.get(), nullptr, nullptr, key.data(), iv ),
+    check( EVP_EncryptInit_ex( e_ctx.get(), nullptr, nullptr, key.data(), localIv ),
         "Failed to set key/IV" );
 
     // Process AAD if provided (authenticated but not encrypted)

--- a/threshold_encryption/AesGcmCipher.h
+++ b/threshold_encryption/AesGcmCipher.h
@@ -66,9 +66,10 @@ class AesGcmCipher {
 private:
     AES256Key key;
 
-    //
+    // Whether the cipher is deterministic (i.e. uses HKDF to derive key from seed)
     bool isDeterministic;
-    uint64_t encryptCounter;  // Counter for deterministic IV generation
+    // Counter for deterministic IV generation
+    uint64_t encryptCounter;
     std::array< uint8_t, AES_GCM_IV_SIZE > iv;
 
 public:

--- a/threshold_encryption/AesGcmCipher.h
+++ b/threshold_encryption/AesGcmCipher.h
@@ -59,13 +59,31 @@ struct EvpContextDeleter {
 
 using UniqueCtx = std::unique_ptr< EVP_CIPHER_CTX, EvpContextDeleter >;
 
+/// Tag type to distinguish raw key constructor from seed constructor
+enum class KeyType { Raw };
 
 class AesGcmCipher {
 private:
     AES256Key key;
 
+    //
+    bool isDeterministic;
+    uint64_t encryptCounter;  // Counter for deterministic IV generation
+    std::array< uint8_t, AES_GCM_IV_SIZE > iv;
+
 public:
-    AesGcmCipher( const AES256Key& key ) : key( key ) {}
+    /// @brief Creates cipher with random key (for encryption)
+    AesGcmCipher();
+
+    /// @brief Creates cipher with key derived from seed (for deterministic encryption)
+    /// @param seed The seed to derive key from using HKDF
+    AesGcmCipher( const std::array< uint8_t, AES_256_KEY_SIZE_BYTES >& seed );
+
+    /// @brief Creates cipher with a known raw key (for decryption)
+    /// @param key The raw AES-256 key to use
+    /// @param tag KeyType::Raw to indicate this is a raw key, not a seed
+    AesGcmCipher( const AES256Key& key, KeyType tag );
+
     ~AesGcmCipher() = default;
 
     /// @brief Encrypts the given plaintext using AES-256-GCM
@@ -82,6 +100,10 @@ public:
     /// @return Decrypted message
     std::vector< uint8_t > decrypt( const std::vector< uint8_t >& ciphertext,
         const std::optional< std::vector< uint8_t > >& aad = std::nullopt );
+
+    /// @brief Returns the AES key (for use as plaintext in threshold encryption)
+    /// @return Reference to the 32-byte AES key
+    const AES256Key& getKey() const { return key; }
 
 private:
     /// Helper function to check if the operation was successful

--- a/threshold_encryption/AesGcmCipher.h
+++ b/threshold_encryption/AesGcmCipher.h
@@ -44,6 +44,12 @@ constexpr size_t AES_GCM_TAG_SIZE = 16;
 
 using AES256Key = std::array< uint8_t, AES_256_KEY_SIZE_BYTES >;
 
+/// Strong type wrapper for 256-bit seed (used for deterministic key derivation)
+/// This seed is used to derive both the AES key (via HKDF) and the TE scalar secret.
+struct Seed256 {
+    std::array< uint8_t, AES_256_KEY_SIZE_BYTES > data;
+};
+
 
 /// -------------------------------
 ///     EVP_CONTEXT wrapper
@@ -58,9 +64,6 @@ struct EvpContextDeleter {
 };
 
 using UniqueCtx = std::unique_ptr< EVP_CIPHER_CTX, EvpContextDeleter >;
-
-/// Tag type to distinguish raw key constructor from seed constructor
-enum class KeyType { Raw };
 
 class AesGcmCipher {
 private:
@@ -77,13 +80,12 @@ public:
     AesGcmCipher();
 
     /// @brief Creates cipher with key derived from seed (for deterministic encryption)
-    /// @param seed The seed to derive key from using HKDF
-    AesGcmCipher( const std::array< uint8_t, AES_256_KEY_SIZE_BYTES >& seed );
+    /// @param seed The Seed256 wrapper containing the seed to derive key from using HKDF
+    explicit AesGcmCipher( const Seed256& seed );
 
     /// @brief Creates cipher with a known raw key (for decryption)
-    /// @param key The raw AES-256 key to use
-    /// @param tag KeyType::Raw to indicate this is a raw key, not a seed
-    AesGcmCipher( const AES256Key& key, KeyType tag );
+    /// @param key The raw AES-256 key to use directly (no derivation)
+    explicit AesGcmCipher( const AES256Key& key );
 
     ~AesGcmCipher() = default;
 

--- a/threshold_encryption/ThresholdEncryption.cpp
+++ b/threshold_encryption/ThresholdEncryption.cpp
@@ -53,7 +53,7 @@ std::vector< uint8_t > ThresholdEncryption::mockupEncrypt(
     messageToCipher.insert( messageToCipher.end(), randomSecret.begin(), randomSecret.end() );
 
     // Cipher message + random secret using AES key
-    AesGcmCipher aesGcmCipher{ key, KeyType::Raw };
+    AesGcmCipher aesGcmCipher{ key };
     auto encryptedMessage = aesGcmCipher.encrypt( messageToCipher );
 
     // 0x01 byte is needed for compatibility with real encryption
@@ -88,7 +88,7 @@ std::vector< uint8_t > ThresholdEncryption::mockupDecrypt(
         _encryptedData.begin() + CipheredKey::CIPHERED_KEY_SIZE_BYTES + 1, _encryptedData.end() );
 
     // Decrypt the data
-    AesGcmCipher aesGcmCipher{ key, KeyType::Raw };
+    AesGcmCipher aesGcmCipher{ key };
     std::vector< uint8_t > decrypted = aesGcmCipher.decrypt( cipher_text );
 
     if ( decrypted.size() < RANDOM_SECRET_SIZE_BYTES ) {
@@ -534,7 +534,7 @@ void ThresholdEncryption::validateDecipheredMessage(
 
 std::vector< uint8_t > ThresholdEncryption::decipherAESAndValidate( const Ciphertext& _ciphertext,
     const AES256Key& _key, const std::optional< std::vector< uint8_t > >& _associatedData ) {
-    AesGcmCipher aesGcmCipher{ _key, KeyType::Raw };
+    AesGcmCipher aesGcmCipher{ _key };
     std::vector< uint8_t > data = aesGcmCipher.decrypt( _ciphertext.getData(), _associatedData );
 
     // validate output

--- a/threshold_encryption/ThresholdEncryption.cpp
+++ b/threshold_encryption/ThresholdEncryption.cpp
@@ -53,7 +53,7 @@ std::vector< uint8_t > ThresholdEncryption::mockupEncrypt(
     messageToCipher.insert( messageToCipher.end(), randomSecret.begin(), randomSecret.end() );
 
     // Cipher message + random secret using AES key
-    AesGcmCipher aesGcmCipher{ key };
+    AesGcmCipher aesGcmCipher{ key, KeyType::Raw };
     auto encryptedMessage = aesGcmCipher.encrypt( messageToCipher );
 
     // 0x01 byte is needed for compatibility with real encryption
@@ -88,7 +88,7 @@ std::vector< uint8_t > ThresholdEncryption::mockupDecrypt(
         _encryptedData.begin() + CipheredKey::CIPHERED_KEY_SIZE_BYTES + 1, _encryptedData.end() );
 
     // Decrypt the data
-    AesGcmCipher aesGcmCipher{ key };
+    AesGcmCipher aesGcmCipher{ key, KeyType::Raw };
     std::vector< uint8_t > decrypted = aesGcmCipher.decrypt( cipher_text );
 
     if ( decrypted.size() < RANDOM_SECRET_SIZE_BYTES ) {
@@ -120,8 +120,7 @@ Ciphertext ThresholdEncryption::encrypt( const std::vector< uint8_t >& _message,
         rawPublicKeys.push_back( publicKey.getPublicKeyRaw() );
     }
 
-    CipherResult cipher = TE::encryptWithAES(
-        _message, rawPublicKeys, _metaData.associatedDataAesCbc, _metaData.associatedDataTE );
+    CipherResult cipher = TE::encryptWithAES( _message, rawPublicKeys, _metaData );
 
     if ( !cipher.ciphertext ) {
         throw ThresholdUtils::IsNotWellFormed( "ciphertext is null" );
@@ -535,7 +534,7 @@ void ThresholdEncryption::validateDecipheredMessage(
 
 std::vector< uint8_t > ThresholdEncryption::decipherAESAndValidate( const Ciphertext& _ciphertext,
     const AES256Key& _key, const std::optional< std::vector< uint8_t > >& _associatedData ) {
-    AesGcmCipher aesGcmCipher{ _key };
+    AesGcmCipher aesGcmCipher{ _key, KeyType::Raw };
     std::vector< uint8_t > data = aesGcmCipher.decrypt( _ciphertext.getData(), _associatedData );
 
     // validate output

--- a/threshold_encryption/ThresholdEncryption.h
+++ b/threshold_encryption/ThresholdEncryption.h
@@ -24,6 +24,7 @@
 #ifndef LIBBLS_THRESHOLDENCRYPTION_H
 #define LIBBLS_THRESHOLDENCRYPTION_H
 
+#include "AesGcmCipher.h"
 #include "TEDecryptSet.h"
 #include "TEPrivateKeyShare.h"
 #include "TEPublicKeyShare.h"
@@ -46,19 +47,6 @@ class ThresholdEncryption {
 public:
     static std::vector< uint8_t > mockupEncrypt( const std::vector< uint8_t >& _message );
     static std::vector< uint8_t > mockupDecrypt( const std::vector< uint8_t >& _encryptedData );
-
-    struct EncryptMetaData {
-        // Optional associated data for AES CBC
-        // Is used at encryption and at decryption stages only. Does not obey to threshold
-        // guarantees since it is associated with symmetric encryption.
-        std::optional< std::vector< uint8_t > > associatedDataAesCbc;
-
-        // Optional associated data for TE
-        // Is used at encryption and validateEncryption stages only. Obeys to threshold guarantees
-        // as long as no party proceeds with the algorithm (partial decryption) in case
-        // validateEncryption fails with this associated data.
-        std::optional< std::vector< uint8_t > > associatedDataTE;
-    };
 
     /**
      * @brief Encrypts a message using threshold encryption.

--- a/threshold_encryption/encryptMessage.cpp
+++ b/threshold_encryption/encryptMessage.cpp
@@ -41,7 +41,7 @@ const char* encryptMessage( const char* data, const char* key,
     libBLS::TEPublicKey commonPublic( keyStr, libBLS::Base::HEXA );
 
     // build encrypt meta data
-    libBLS::ThresholdEncryption::EncryptMetaData metaData;
+    libBLS::EncryptMetaData metaData;
 
     // set AAD AES if not empty
     if ( additionalAuthenticatedDataAES != nullptr && additionalAuthenticatedDataAES[0] != '\0' ) {
@@ -85,7 +85,7 @@ const char* encryptMessageDualKey( const char* data, const char* firstKey, const
     commonPublicKeys.push_back( secondCommonPublic );
 
     // Build meta data
-    libBLS::ThresholdEncryption::EncryptMetaData metaData;
+    libBLS::EncryptMetaData metaData;
 
     // set AAD AES if not empty
     if ( additionalAuthenticatedDataAES != nullptr && additionalAuthenticatedDataAES[0] != '\0' ) {

--- a/threshold_encryption/threshold_encryption.cpp
+++ b/threshold_encryption/threshold_encryption.cpp
@@ -64,6 +64,7 @@ algebra::G1Point TE::HashToGroup(
 
     // Build hash input: U coordinates + V + optional AAD
     std::string hashInput = uStr[0] + uStr[1] + uStr[2] + uStr[3] + vStr;
+
     if ( associatedData && !associatedData->empty() ) {
         std::string aadStr = ThresholdUtils::bytesToHexString( *associatedData );
         hashInput += aadStr;
@@ -85,24 +86,58 @@ algebra::G1Point TE::HashToGroup(
 
 
 CipheredKeyResult TE::getCiphertext( const AES256Key& key, const algebra::G2Point& commonPublic,
-    const std::vector< uint8_t >* associatedDataTE ) {
-    return getCiphertext( key, std::vector< algebra::G2Point >{ commonPublic }, associatedDataTE );
+    const std::optional< std::vector< uint8_t > >& associatedDataTE,
+    const std::optional< std::array< uint8_t, AES_256_KEY_SIZE_BYTES > >& seed ) {
+    return getCiphertext(
+        key, std::vector< algebra::G2Point >{ commonPublic }, associatedDataTE, seed );
 }
 
 
 CipheredKeyResult TE::getCiphertext( const AES256Key& key,
     const std::vector< algebra::G2Point >& commonPublicVector,
-    const std::vector< uint8_t >* associatedDataTE ) {
+    const std::optional< std::vector< uint8_t > >& associatedDataTE,
+    const std::optional< std::array< uint8_t, AES_256_KEY_SIZE_BYTES > >& seed ) {
     algebra::FrScalar r = algebra::FrScalar::random();
 
-    while ( r.isZero() ) {
+    // set first value for r scalar
+    if ( seed.has_value() && !seed->empty() ) {
+        // Derive scalar r using SHA256 with domain separation
+        // derivation: SHA256( seed || "Scalar" )
+        std::vector< uint8_t > input( seed->begin(), seed->end() );
+        const std::string domain = "Scalar";
+        input.insert( input.end(), domain.begin(), domain.end() );
+
+        std::string inputStr( input.begin(), input.end() );
+        std::string hashHex = ThresholdUtils::sha256( inputStr );
+        std::vector< uint8_t > derivedScalar = ThresholdUtils::hexCStringToBytes( hashHex.c_str() );
+
+        // This maps the 32-byte hash into the scalar field (handling modulo prime order etc)
+        r = algebra::FrScalar::fromHashBytes( derivedScalar.data(), derivedScalar.size() );
+    } else {
         r = algebra::FrScalar::random();
+    }
+
+    // make sure it is different from zero
+    while ( r.isZero() ) {
+        if ( seed.has_value() && !seed->empty() ) {
+            // Very unlikely case where the derived scalar is zero
+            // We can re-hash the derived scalar to get a new one
+            std::string hashHex = ThresholdUtils::sha256( r.toString( Base::HEXA ) );
+            std::vector< uint8_t > derivedScalar =
+                ThresholdUtils::hexCStringToBytes( hashHex.c_str() );
+            r = algebra::FrScalar::fromHashBytes( derivedScalar.data(), derivedScalar.size() );
+        } else {
+            r = algebra::FrScalar::random();
+        }
     }
 
     std::vector< CipheredKey > cipheredKeys;
     algebra::G2Point U = r * algebra::G2Point::generator();
     // convert to affine coordinate here to avoid doing it twice inside the loop
     U.toAffineCoordinates();
+
+    const auto aadPtr = associatedDataTE.has_value() ? &associatedDataTE.value() : nullptr;
+
     for ( const auto& commonPublic : commonPublicVector ) {
         algebra::G2Point Y;
         Y = r * commonPublic;
@@ -123,7 +158,7 @@ CipheredKeyResult TE::getCiphertext( const AES256Key& key,
 
         algebra::G1Point W, H;
 
-        H = HashToGroup( U, V, associatedDataTE );
+        H = HashToGroup( U, V, aadPtr );
         W = r * H;
 
         cipheredKeys.emplace_back( U, V, W );
@@ -154,26 +189,28 @@ CipheredKeyResult TE::getCiphertext( const AES256Key& key,
  * @note Initializes AES before encryption
  */
 CipherResult TE::encryptWithAES( const std::vector< uint8_t >& message,
-    const algebra::G2Point& commonPublic,
-    const std::optional< std::vector< uint8_t > >& associatedDataAES,
-    const std::optional< std::vector< uint8_t > >& associatedDataTE ) {
-    return encryptWithAES( message, std::vector< algebra::G2Point >{ commonPublic },
-        associatedDataAES, associatedDataTE );
+    const algebra::G2Point& commonPublic, const EncryptMetaData& metaData ) {
+    return encryptWithAES( message, std::vector< algebra::G2Point >{ commonPublic }, metaData );
 }
 
 CipherResult TE::encryptWithAES( const std::vector< uint8_t >& message,
-    const std::vector< algebra::G2Point >& commonPublic,
-    const std::optional< std::vector< uint8_t > >& associatedDataAES,
-    const std::optional< std::vector< uint8_t > >& associatedDataTE ) {
-    // create random AES key
-    AES256Key key;
-    if ( RAND_bytes( key.data(), key.size() ) != 1 ) {
-        throw ThresholdUtils::IsNotWellFormed( "Failed to generate random key" );
+    const std::vector< algebra::G2Point >& commonPublic, const EncryptMetaData& metaData ) {
+    // Create AesGcmCipher - delegates key generation/derivation to the class
+    // If seed is provided, key is derived deterministically; otherwise random
+    std::unique_ptr< AesGcmCipher > aesGcmCipher;
+    if ( metaData.seed.has_value() ) {
+        aesGcmCipher = std::make_unique< AesGcmCipher >( metaData.seed.value() );
+    } else {
+        aesGcmCipher = std::make_unique< AesGcmCipher >();
     }
+
+    // Get the key from cipher for threshold encryption
+    const AES256Key& key = aesGcmCipher->getKey();
+
     // cipher aes key (with optional TE AAD)
-    const std::vector< uint8_t >* aadPtr =
-        associatedDataTE.has_value() ? &*associatedDataTE : nullptr;
-    CipheredKeyResult result = getCiphertext( key, commonPublic, aadPtr );
+
+    CipheredKeyResult result =
+        getCiphertext( key, commonPublic, metaData.associatedDataTE, metaData.seed );
 
     // append random secret to end of message
     std::vector< uint8_t > messageToCipher( message );
@@ -181,8 +218,7 @@ CipherResult TE::encryptWithAES( const std::vector< uint8_t >& message,
         messageToCipher.end(), result.randomSecret.begin(), result.randomSecret.end() );
 
     // cipher message + random secret using AES key (with optional AES AAD)
-    AesGcmCipher aesGcmCipher{ key };
-    auto encryptedMessage = aesGcmCipher.encrypt( messageToCipher, associatedDataAES );
+    auto encryptedMessage = aesGcmCipher->encrypt( messageToCipher, metaData.associatedDataAesCbc );
 
     std::shared_ptr< Ciphertext > ciphertext =
         std::make_shared< Ciphertext >( result.ciphertext, encryptedMessage );

--- a/threshold_encryption/threshold_encryption.cpp
+++ b/threshold_encryption/threshold_encryption.cpp
@@ -87,7 +87,7 @@ algebra::G1Point TE::HashToGroup(
 
 CipheredKeyResult TE::getCiphertext( const AES256Key& key, const algebra::G2Point& commonPublic,
     const std::optional< std::vector< uint8_t > >& associatedDataTE,
-    const std::optional< std::array< uint8_t, AES_256_KEY_SIZE_BYTES > >& seed ) {
+    const std::optional< Seed256 >& seed ) {
     return getCiphertext(
         key, std::vector< algebra::G2Point >{ commonPublic }, associatedDataTE, seed );
 }
@@ -96,14 +96,14 @@ CipheredKeyResult TE::getCiphertext( const AES256Key& key, const algebra::G2Poin
 CipheredKeyResult TE::getCiphertext( const AES256Key& key,
     const std::vector< algebra::G2Point >& commonPublicVector,
     const std::optional< std::vector< uint8_t > >& associatedDataTE,
-    const std::optional< std::array< uint8_t, AES_256_KEY_SIZE_BYTES > >& seed ) {
+    const std::optional< Seed256 >& seed ) {
     algebra::FrScalar r = algebra::FrScalar::random();
 
     // set first value for r scalar
     if ( seed.has_value() ) {
         // Derive scalar r using SHA256 with domain separation
         // derivation: SHA256( seed || "Scalar" )
-        std::vector< uint8_t > input( seed->begin(), seed->end() );
+        std::vector< uint8_t > input( seed->data.begin(), seed->data.end() );
         const std::string domain = "Scalar";
         input.insert( input.end(), domain.begin(), domain.end() );
 

--- a/threshold_encryption/threshold_encryption.cpp
+++ b/threshold_encryption/threshold_encryption.cpp
@@ -100,7 +100,7 @@ CipheredKeyResult TE::getCiphertext( const AES256Key& key,
     algebra::FrScalar r = algebra::FrScalar::random();
 
     // set first value for r scalar
-    if ( seed.has_value() && !seed->empty() ) {
+    if ( seed.has_value() ) {
         // Derive scalar r using SHA256 with domain separation
         // derivation: SHA256( seed || "Scalar" )
         std::vector< uint8_t > input( seed->begin(), seed->end() );
@@ -119,7 +119,7 @@ CipheredKeyResult TE::getCiphertext( const AES256Key& key,
 
     // make sure it is different from zero
     while ( r.isZero() ) {
-        if ( seed.has_value() && !seed->empty() ) {
+        if ( seed.has_value() ) {
             // Very unlikely case where the derived scalar is zero
             // We can re-hash the derived scalar to get a new one
             std::string hashHex = ThresholdUtils::sha256( r.toString( Base::HEXA ) );

--- a/threshold_encryption/threshold_encryption.h
+++ b/threshold_encryption/threshold_encryption.h
@@ -58,6 +58,27 @@ struct CipheredKeyResult {
     RandSecret randomSecret;
 };
 
+
+/**
+ * @brief Metadata used during encryption
+ */
+struct EncryptMetaData {
+    // Optional associated data for AES CBC
+    // Is used at encryption and at decryption stages only. Does not obey to threshold
+    // guarantees since it is associated with symmetric encryption.
+    std::optional< std::vector< uint8_t > > associatedDataAesCbc;
+
+    // Optional associated data for TE
+    // Is used at encryption and validateEncryption stages only. Obeys to threshold guarantees
+    // as long as no party proceeds with the algorithm (partial decryption) in case
+    // validateEncryption fails with this associated data.
+    std::optional< std::vector< uint8_t > > associatedDataTE;
+
+    // Optional seed used to derive both the random scalar secret and the AES key.
+    // Seed must have same size as AES_KEY in order to have the same entropy / security level.
+    std::optional< std::array< uint8_t, AES_256_KEY_SIZE_BYTES > > seed;
+};
+
 class TE {
 public:
     TE( const TEBase& base );
@@ -65,7 +86,6 @@ public:
     TE( const size_t t, const size_t n );
 
     ~TE();
-
 
     /**
      * @brief Encrypts a message using threshold encryption scheme
@@ -85,21 +105,21 @@ public:
      */
     static CipheredKeyResult getCiphertext( const AES256Key& key,
         const algebra::G2Point& commonPublic,
-        const std::vector< uint8_t >* associatedDataTE = nullptr );
+        const std::optional< std::vector< uint8_t > >& associatedDataTE,
+        const std::optional< std::array< uint8_t, AES_256_KEY_SIZE_BYTES > >& seed );
 
     static CipheredKeyResult getCiphertext( const AES256Key& key,
         const std::vector< algebra::G2Point >& commonPublic,
-        const std::vector< uint8_t >* associatedDataTE = nullptr );
+        const std::optional< std::vector< uint8_t > >& associatedDataTE,
+        const std::optional< std::array< uint8_t, AES_256_KEY_SIZE_BYTES > >& seed );
 
     static CipherResult encryptWithAES( const std::vector< uint8_t >& message,
         const algebra::G2Point& commonPublic,
-        const std::optional< std::vector< uint8_t > >& associatedDataAES = std::nullopt,
-        const std::optional< std::vector< uint8_t > >& associatedDataTE = std::nullopt );
+        const EncryptMetaData& metaData = EncryptMetaData() );
 
     static CipherResult encryptWithAES( const std::vector< uint8_t >& message,
         const std::vector< algebra::G2Point >& commonPublic,
-        const std::optional< std::vector< uint8_t > >& associatedDataAES = std::nullopt,
-        const std::optional< std::vector< uint8_t > >& associatedDataTE = std::nullopt );
+        const EncryptMetaData& metaData = EncryptMetaData() );
 
     static std::pair< std::string, RandSecret > encryptMessage(
         const std::vector< uint8_t >& message, const std::string& commonPublic );

--- a/threshold_encryption/threshold_encryption.h
+++ b/threshold_encryption/threshold_encryption.h
@@ -114,8 +114,7 @@ public:
         const std::optional< std::array< uint8_t, AES_256_KEY_SIZE_BYTES > >& seed );
 
     static CipherResult encryptWithAES( const std::vector< uint8_t >& message,
-        const algebra::G2Point& commonPublic,
-        const EncryptMetaData& metaData = EncryptMetaData() );
+        const algebra::G2Point& commonPublic, const EncryptMetaData& metaData = EncryptMetaData() );
 
     static CipherResult encryptWithAES( const std::vector< uint8_t >& message,
         const std::vector< algebra::G2Point >& commonPublic,

--- a/threshold_encryption/threshold_encryption.h
+++ b/threshold_encryption/threshold_encryption.h
@@ -76,7 +76,7 @@ struct EncryptMetaData {
 
     // Optional seed used to derive both the random scalar secret and the AES key.
     // Seed must have same size as AES_KEY in order to have the same entropy / security level.
-    std::optional< std::array< uint8_t, AES_256_KEY_SIZE_BYTES > > seed;
+    std::optional< Seed256 > seed;
 };
 
 class TE {
@@ -106,12 +106,12 @@ public:
     static CipheredKeyResult getCiphertext( const AES256Key& key,
         const algebra::G2Point& commonPublic,
         const std::optional< std::vector< uint8_t > >& associatedDataTE,
-        const std::optional< std::array< uint8_t, AES_256_KEY_SIZE_BYTES > >& seed );
+        const std::optional< Seed256 >& seed );
 
     static CipheredKeyResult getCiphertext( const AES256Key& key,
         const std::vector< algebra::G2Point >& commonPublic,
         const std::optional< std::vector< uint8_t > >& associatedDataTE,
-        const std::optional< std::array< uint8_t, AES_256_KEY_SIZE_BYTES > >& seed );
+        const std::optional< Seed256 >& seed );
 
     static CipherResult encryptWithAES( const std::vector< uint8_t >& message,
         const algebra::G2Point& commonPublic, const EncryptMetaData& metaData = EncryptMetaData() );


### PR DESCRIPTION
## Summary

Adds support for deterministic encryption in `AesGcmCipher` and threshold encryption. When a seed is provided, both the **AES key**, **random scalar r** and **encryption IV** are derived deterministically, ensuring that any two nodes using the same seed will produce identical ciphertexts.

## Changes
#### `AesGcmCipher` class:

- Added 3 constructor modes:
    - `AesGcmCipher()` - Random key generation
    - `AesGcmCipher(seed)` - Deterministic key from seed (HKDF-SHA256) with counter-based synthetic IV
    - `AesGcmCipher(key, KeyType::Raw)` - Use existing key directly (for decryption)
 
- Added `getKey()` method to expose the generated/derived key
- Counter-based IV ensures same plaintext encrypted multiple times produces different ciphertexts while maintaining cross-node determinism

#### Threshold Encryption:

- Refactored `encryptWithAES()` to delegate key generation to `AesGcmCipher`
- Updated all call sites to use KeyType::Raw for decryption scenarios

#### Testing
- Added 7 new `AesGcmCipher`  tests (random, seeded, cross-node determinism)
- Added 3 new `ThresholdEncryption` wrapper tests:
    - `TESeededCrossNodeDeterminism`
    - `TESeededMultipleMessageSequence`
    - `TESeededEncryptionDecryptionFlow`
    
    
Fixes #278 