### PR TITLE
Update AAD TE validation API

### DIFF
--- a/test/test_TE_wrappers.cpp
+++ b/test/test_TE_wrappers.cpp
@@ -647,8 +647,8 @@ BOOST_AUTO_TEST_CASE( TEDecryptionSharesBatchValidationWithPartialAAD ) {
     }
 
     // Test with wrong AAD on first 2 - should fail, last 2 should still pass
-    std::vector< std::vector< uint8_t > > wrongAadVec = {
-        { 0xFF, 0xFF, 0x00 }, { 0xFF, 0xFF, 0x01 } };
+    std::vector< std::vector< uint8_t > > wrongAadVec = { { 0xFF, 0xFF, 0x00 },
+        { 0xFF, 0xFF, 0x01 } };
 
     auto wrongResults = libBLS::ThresholdEncryption::validateDecryptionSharesBatch(
         cipheredKeys, shares, pubKeys, &wrongAadVec );

--- a/test/test_TE_wrappers.cpp
+++ b/test/test_TE_wrappers.cpp
@@ -430,6 +430,286 @@ BOOST_AUTO_TEST_CASE( TEBatchValidationWithAAD ) {
     }
 }
 
+BOOST_AUTO_TEST_CASE( TEBatchValidationWithPartialAAD ) {
+    // Test batch validation with partial AAD (fewer AADs than ciphertexts)
+    size_t numAll = 4;
+    size_t numSigned = 3;
+
+    keys keys = generateKeys( numSigned, numAll );
+    std::vector< uint8_t > message = randomByteVec( 100 );
+
+    // Create 5 ciphertexts: first 3 with AAD, last 2 without AAD
+    size_t batchSize = 5;
+    size_t aadCount = 3;
+    std::vector< libBLS::CipheredKey > cipheredKeys;
+    std::vector< std::vector< uint8_t > > aadVec;
+
+    // First 3 ciphertexts encrypted WITH AAD
+    for ( size_t i = 0; i < aadCount; ++i ) {
+        std::vector< uint8_t > aadTE = { 0x01, 0x02, 0x03, static_cast< uint8_t >( i ) };
+        aadVec.push_back( aadTE );
+
+        libBLS::EncryptMetaData metaData;
+        metaData.associatedDataTE = aadTE;
+
+        libBLS::Ciphertext cypher =
+            libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic, metaData );
+        cipheredKeys.push_back( cypher.getKeys()[0] );
+    }
+
+    // Last 2 ciphertexts encrypted WITHOUT AAD
+    for ( size_t i = aadCount; i < batchSize; ++i ) {
+        libBLS::Ciphertext cypher =
+            libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic );
+        cipheredKeys.push_back( cypher.getKeys()[0] );
+    }
+
+    // Batch validate with partial AAD (3 AADs for 5 ciphertexts)
+    // First 3 should validate with their AAD, last 2 should validate without AAD
+    auto results = libBLS::ThresholdEncryption::validateEncryptionBatch( cipheredKeys, &aadVec );
+    BOOST_REQUIRE( results.size() == batchSize );
+    for ( size_t i = 0; i < batchSize; ++i ) {
+        BOOST_REQUIRE( results[i] == true );
+    }
+
+    // Test parallel version
+    auto resultsParallel =
+        libBLS::ThresholdEncryption::validateEncryptionBatchParallel( cipheredKeys, &aadVec );
+    BOOST_REQUIRE( resultsParallel.size() == batchSize );
+    for ( size_t i = 0; i < batchSize; ++i ) {
+        BOOST_REQUIRE( resultsParallel[i] == true );
+    }
+
+    // Verify that wrong AAD on first 3 fails, while last 2 still pass (no AAD)
+    std::vector< std::vector< uint8_t > > wrongAadVec;
+    for ( size_t i = 0; i < aadCount; ++i ) {
+        wrongAadVec.push_back( { 0xFF, 0xFE, 0xFD, static_cast< uint8_t >( i ) } );
+    }
+
+    auto wrongResults =
+        libBLS::ThresholdEncryption::validateEncryptionBatch( cipheredKeys, &wrongAadVec );
+    BOOST_REQUIRE( wrongResults.size() == batchSize );
+    // First 3 should fail (wrong AAD)
+    for ( size_t i = 0; i < aadCount; ++i ) {
+        BOOST_REQUIRE( wrongResults[i] == false );
+    }
+    // Last 2 should pass (no AAD required)
+    for ( size_t i = aadCount; i < batchSize; ++i ) {
+        BOOST_REQUIRE( wrongResults[i] == true );
+    }
+}
+
+BOOST_AUTO_TEST_CASE( TEBatchValidationWithEmptyAADEntries ) {
+    // Test batch validation where some AAD entries are empty vectors
+    size_t numAll = 4;
+    size_t numSigned = 3;
+
+    keys keys = generateKeys( numSigned, numAll );
+    std::vector< uint8_t > message = randomByteVec( 100 );
+
+    size_t batchSize = 4;
+    std::vector< libBLS::CipheredKey > cipheredKeys;
+    std::vector< std::vector< uint8_t > > aadVec;
+
+    // Create ciphertexts: 0->with AAD, 1->without AAD, 2->with AAD, 3->without AAD
+    for ( size_t i = 0; i < batchSize; ++i ) {
+        if ( i % 2 == 0 ) {
+            // Even indices: encrypt WITH AAD
+            std::vector< uint8_t > aadTE = { 0xAA, 0xBB, static_cast< uint8_t >( i ) };
+            aadVec.push_back( aadTE );
+
+            libBLS::EncryptMetaData metaData;
+            metaData.associatedDataTE = aadTE;
+
+            libBLS::Ciphertext cypher =
+                libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic, metaData );
+            cipheredKeys.push_back( cypher.getKeys()[0] );
+        } else {
+            // Odd indices: encrypt WITHOUT AAD and push empty AAD vector
+            aadVec.push_back( {} );  // empty AAD
+
+            libBLS::Ciphertext cypher =
+                libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic );
+            cipheredKeys.push_back( cypher.getKeys()[0] );
+        }
+    }
+
+    // Batch validate - empty AAD should be treated as no AAD
+    auto results = libBLS::ThresholdEncryption::validateEncryptionBatch( cipheredKeys, &aadVec );
+    BOOST_REQUIRE( results.size() == batchSize );
+    for ( size_t i = 0; i < batchSize; ++i ) {
+        BOOST_REQUIRE( results[i] == true );
+    }
+
+    // Test parallel version
+    auto resultsParallel =
+        libBLS::ThresholdEncryption::validateEncryptionBatchParallel( cipheredKeys, &aadVec );
+    BOOST_REQUIRE( resultsParallel.size() == batchSize );
+    for ( size_t i = 0; i < batchSize; ++i ) {
+        BOOST_REQUIRE( resultsParallel[i] == true );
+    }
+}
+
+BOOST_AUTO_TEST_CASE( TEBatchValidationRejectsExcessiveAAD ) {
+    // Test that batch validation throws when AAD vector is larger than ciphertext vector
+    size_t numAll = 4;
+    size_t numSigned = 3;
+
+    keys keys = generateKeys( numSigned, numAll );
+    std::vector< uint8_t > message = randomByteVec( 100 );
+
+    size_t batchSize = 3;
+    std::vector< libBLS::CipheredKey > cipheredKeys;
+    std::vector< std::vector< uint8_t > > aadVec;
+
+    // Create 3 ciphertexts
+    for ( size_t i = 0; i < batchSize; ++i ) {
+        libBLS::Ciphertext cypher =
+            libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic );
+        cipheredKeys.push_back( cypher.getKeys()[0] );
+    }
+
+    // Create 5 AAD entries (more than ciphertexts)
+    for ( size_t i = 0; i < 5; ++i ) {
+        aadVec.push_back( { 0x01, 0x02, static_cast< uint8_t >( i ) } );
+    }
+
+    // Should throw: AAD size cannot exceed ciphertext size
+    BOOST_REQUIRE_THROW(
+        libBLS::ThresholdEncryption::validateEncryptionBatch( cipheredKeys, &aadVec ),
+        libBLS::ThresholdUtils::IncorrectInput );
+
+    BOOST_REQUIRE_THROW(
+        libBLS::ThresholdEncryption::validateEncryptionBatchParallel( cipheredKeys, &aadVec ),
+        libBLS::ThresholdUtils::IncorrectInput );
+}
+
+BOOST_AUTO_TEST_CASE( TEDecryptionSharesBatchValidationWithPartialAAD ) {
+    // Test batch validation of decryption shares with partial AAD
+    size_t numAll = 4;
+    size_t numSigned = 3;
+
+    keys keys = generateKeys( numSigned, numAll );
+    std::vector< uint8_t > message = randomByteVec( 100 );
+
+    // Create 4 ciphertexts: first 2 with AAD, last 2 without
+    size_t batchSize = 4;
+    size_t aadCount = 2;
+    std::vector< libBLS::CipheredKey > cipheredKeys;
+    std::vector< std::vector< uint8_t > > aadVec;
+
+    // First 2 with AAD
+    for ( size_t i = 0; i < aadCount; ++i ) {
+        std::vector< uint8_t > aadTE = { 0x10, 0x20, static_cast< uint8_t >( i ) };
+        aadVec.push_back( aadTE );
+
+        libBLS::EncryptMetaData metaData;
+        metaData.associatedDataTE = aadTE;
+
+        libBLS::Ciphertext cypher =
+            libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic, metaData );
+        cipheredKeys.push_back( cypher.getKeys()[0] );
+    }
+
+    // Last 2 without AAD
+    for ( size_t i = aadCount; i < batchSize; ++i ) {
+        libBLS::Ciphertext cypher =
+            libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic );
+        cipheredKeys.push_back( cypher.getKeys()[0] );
+    }
+
+    // Generate decryption shares for all ciphertexts from all signers
+    std::vector< libBLS::TEDecryptionShare > shares;
+    std::vector< libBLS::TEPublicKeyShare > pubKeys;
+
+    for ( size_t i = 0; i < batchSize; ++i ) {
+        for ( size_t j = 0; j < numAll; ++j ) {
+            shares.push_back( libBLS::ThresholdEncryption::partialDecrypt(
+                cipheredKeys[i], keys.secretKeys[j] ) );
+            pubKeys.push_back( keys.publicKeys[j] );
+        }
+    }
+
+    // Validate with partial AAD (2 AADs for 4 ciphertexts)
+    auto results = libBLS::ThresholdEncryption::validateDecryptionSharesBatch(
+        cipheredKeys, shares, pubKeys, &aadVec );
+    BOOST_REQUIRE( results.size() == batchSize * numAll );
+    for ( size_t i = 0; i < results.size(); ++i ) {
+        BOOST_REQUIRE( results[i] == true );
+    }
+
+    // Test parallel version
+    auto resultsParallel = libBLS::ThresholdEncryption::validateDecryptionSharesBatchParallel(
+        cipheredKeys, shares, pubKeys, &aadVec );
+    BOOST_REQUIRE( resultsParallel.size() == batchSize * numAll );
+    for ( size_t i = 0; i < resultsParallel.size(); ++i ) {
+        BOOST_REQUIRE( resultsParallel[i] == true );
+    }
+
+    // Test with wrong AAD on first 2 - should fail, last 2 should still pass
+    std::vector< std::vector< uint8_t > > wrongAadVec = {
+        { 0xFF, 0xFF, 0x00 }, { 0xFF, 0xFF, 0x01 } };
+
+    auto wrongResults = libBLS::ThresholdEncryption::validateDecryptionSharesBatch(
+        cipheredKeys, shares, pubKeys, &wrongAadVec );
+
+    for ( size_t i = 0; i < batchSize; ++i ) {
+        for ( size_t j = 0; j < numAll; ++j ) {
+            size_t idx = i * numAll + j;
+            if ( i < aadCount ) {
+                // First 2 ciphertexts: wrong AAD, should fail
+                BOOST_REQUIRE( wrongResults[idx] == false );
+            } else {
+                // Last 2 ciphertexts: no AAD, should pass
+                BOOST_REQUIRE( wrongResults[idx] == true );
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE( TEDecryptionSharesBatchRejectsExcessiveAAD ) {
+    // Test that decryption share batch validation throws when AAD vector exceeds ciphertext count
+    size_t numAll = 4;
+    size_t numSigned = 3;
+
+    keys keys = generateKeys( numSigned, numAll );
+    std::vector< uint8_t > message = randomByteVec( 100 );
+
+    // Create 2 ciphertexts
+    std::vector< libBLS::CipheredKey > cipheredKeys;
+    for ( size_t i = 0; i < 2; ++i ) {
+        libBLS::Ciphertext cypher =
+            libBLS::ThresholdEncryption::encrypt( message, keys.commonPublic );
+        cipheredKeys.push_back( cypher.getKeys()[0] );
+    }
+
+    // Generate decryption shares
+    std::vector< libBLS::TEDecryptionShare > shares;
+    std::vector< libBLS::TEPublicKeyShare > pubKeys;
+    for ( size_t i = 0; i < 2; ++i ) {
+        for ( size_t j = 0; j < numAll; ++j ) {
+            shares.push_back( libBLS::ThresholdEncryption::partialDecrypt(
+                cipheredKeys[i], keys.secretKeys[j] ) );
+            pubKeys.push_back( keys.publicKeys[j] );
+        }
+    }
+
+    // Create 4 AAD entries (more than 2 ciphertexts)
+    std::vector< std::vector< uint8_t > > aadVec;
+    for ( size_t i = 0; i < 4; ++i ) {
+        aadVec.push_back( { 0x01, static_cast< uint8_t >( i ) } );
+    }
+
+    // Should throw: AAD size cannot exceed ciphertext count
+    BOOST_REQUIRE_THROW( libBLS::ThresholdEncryption::validateDecryptionSharesBatch(
+                             cipheredKeys, shares, pubKeys, &aadVec ),
+        libBLS::ThresholdUtils::IncorrectInput );
+
+    BOOST_REQUIRE_THROW( libBLS::ThresholdEncryption::validateDecryptionSharesBatchParallel(
+                             cipheredKeys, shares, pubKeys, &aadVec ),
+        libBLS::ThresholdUtils::IncorrectInput );
+}
+
 
 BOOST_AUTO_TEST_CASE( TEEncryptDeterministicSeededKeyAndScalar ) {
     const size_t numAll = 4;

--- a/test/unit_tests_te.cpp
+++ b/test/unit_tests_te.cpp
@@ -348,6 +348,141 @@ BOOST_AUTO_TEST_CASE( AESWithEmptyAAD ) {
     BOOST_REQUIRE( decryptedText2 == messageBytes );
 }
 
+BOOST_AUTO_TEST_CASE( AESWithTamperedCiphertext ) {
+    libBLS::ThresholdUtils::initRAND();
+    libBLS::AES256Key randomAesKey;
+    RAND_bytes( randomAesKey.data(), randomAesKey.size() );
+
+    const std::string message = "Test message for tampered ciphertext!";
+    std::vector< uint8_t > messageBytes( message.begin(), message.end() );
+    std::vector< uint8_t > aad = { 0x01, 0x02, 0x03, 0x04 };
+
+    libBLS::AesGcmCipher cipher{ randomAesKey };
+
+    // Encrypt with AAD
+    auto ciphertext = cipher.encrypt( messageBytes, aad );
+
+    // Tamper with the ciphertext data (not the IV or tag)
+    if ( ciphertext.size() > libBLS::AES_GCM_IV_SIZE + libBLS::AES_GCM_TAG_SIZE + 1 ) {
+        // ciphertext is between IV (start) and tag (end)
+        ciphertext[libBLS::AES_GCM_IV_SIZE + 5] ^= 0xFF;
+
+        // Decryption should fail due to authentication tag mismatch
+        BOOST_REQUIRE_THROW( cipher.decrypt( ciphertext, aad ), std::runtime_error );
+    }
+}
+
+BOOST_AUTO_TEST_CASE( AESWithTamperedTag ) {
+    libBLS::ThresholdUtils::initRAND();
+    libBLS::AES256Key randomAesKey;
+    RAND_bytes( randomAesKey.data(), randomAesKey.size() );
+
+    const std::string message = "Test message for tampered tag!";
+    std::vector< uint8_t > messageBytes( message.begin(), message.end() );
+    std::vector< uint8_t > aad = { 0xAA, 0xBB, 0xCC };
+
+    libBLS::AesGcmCipher cipher{ randomAesKey };
+
+    // Encrypt with AAD
+    auto ciphertext = cipher.encrypt( messageBytes, aad );
+
+    // Tamper with the authentication tag (last 16 bytes)
+    if ( ciphertext.size() >= libBLS::AES_GCM_TAG_SIZE ) {
+        // tag is at the end of the ciphertext
+        size_t tagStart = ciphertext.size() - libBLS::AES_GCM_TAG_SIZE;
+        ciphertext[tagStart] ^= 0x01;
+
+        // Decryption should fail due to tag mismatch
+        BOOST_REQUIRE_THROW( cipher.decrypt( ciphertext, aad ), std::runtime_error );
+    }
+}
+
+BOOST_AUTO_TEST_CASE( AESWithTamperedIV ) {
+    libBLS::ThresholdUtils::initRAND();
+    libBLS::AES256Key randomAesKey;
+    RAND_bytes( randomAesKey.data(), randomAesKey.size() );
+
+    const std::string message = "Test message for tampered IV!";
+    std::vector< uint8_t > messageBytes( message.begin(), message.end() );
+    std::vector< uint8_t > aad = { 0x11, 0x22, 0x33, 0x44 };
+
+    libBLS::AesGcmCipher cipher{ randomAesKey };
+
+    // Encrypt with AAD
+    auto ciphertext = cipher.encrypt( messageBytes, aad );
+
+    // Tamper with the IV (first 12 bytes)
+    if ( ciphertext.size() >= libBLS::AES_GCM_IV_SIZE ) {
+        // IV is at the start
+        ciphertext[5] ^= 0xAA;
+
+        // Decryption should fail - either due to wrong decryption or tag mismatch
+        BOOST_REQUIRE_THROW( cipher.decrypt( ciphertext, aad ), std::runtime_error );
+    }
+}
+
+BOOST_AUTO_TEST_CASE( AESAADLargePayload ) {
+    libBLS::ThresholdUtils::initRAND();
+    libBLS::AES256Key randomAesKey;
+    RAND_bytes( randomAesKey.data(), randomAesKey.size() );
+
+    // Large message (1 MB)
+    std::vector< uint8_t > largeMessage( 1024 * 1024 );
+    RAND_bytes( largeMessage.data(), largeMessage.size() );
+
+    // Large AAD (64 KB)
+    std::vector< uint8_t > largeAad( 64 * 1024 );
+    RAND_bytes( largeAad.data(), largeAad.size() );
+
+    libBLS::AesGcmCipher cipher{ randomAesKey };
+
+    // Encrypt with large AAD
+    auto ciphertext = cipher.encrypt( largeMessage, largeAad );
+
+    // Decrypt with same large AAD - should succeed
+    auto decrypted = cipher.decrypt( ciphertext, largeAad );
+    BOOST_REQUIRE( decrypted == largeMessage );
+
+    // Modify one byte in the large AAD - should fail
+    largeAad[1234] ^= 0x01;
+    BOOST_REQUIRE_THROW( cipher.decrypt( ciphertext, largeAad ), std::runtime_error );
+}
+
+BOOST_AUTO_TEST_CASE( AESMultipleEncryptionsWithDifferentAAD ) {
+    libBLS::ThresholdUtils::initRAND();
+    libBLS::AES256Key randomAesKey;
+    RAND_bytes( randomAesKey.data(), randomAesKey.size() );
+
+    libBLS::AesGcmCipher cipher{ randomAesKey };
+
+    const std::string msg1 = "First message";
+    const std::string msg2 = "Second message";
+    const std::string msg3 = "Third message";
+
+    std::vector< uint8_t > msg1Bytes( msg1.begin(), msg1.end() );
+    std::vector< uint8_t > msg2Bytes( msg2.begin(), msg2.end() );
+    std::vector< uint8_t > msg3Bytes( msg3.begin(), msg3.end() );
+
+    std::vector< uint8_t > aad1 = { 0x01 };
+    std::vector< uint8_t > aad2 = { 0x02 };
+    std::vector< uint8_t > aad3 = { 0x03 };
+
+    // Encrypt three messages with different AADs
+    auto ct1 = cipher.encrypt( msg1Bytes, aad1 );
+    auto ct2 = cipher.encrypt( msg2Bytes, aad2 );
+    auto ct3 = cipher.encrypt( msg3Bytes, aad3 );
+
+    // Decrypt each with correct AAD
+    BOOST_REQUIRE( cipher.decrypt( ct1, aad1 ) == msg1Bytes );
+    BOOST_REQUIRE( cipher.decrypt( ct2, aad2 ) == msg2Bytes );
+    BOOST_REQUIRE( cipher.decrypt( ct3, aad3 ) == msg3Bytes );
+
+    // Cross-decryption with wrong AAD should fail
+    BOOST_REQUIRE_THROW( cipher.decrypt( ct1, aad2 ), std::runtime_error );
+    BOOST_REQUIRE_THROW( cipher.decrypt( ct2, aad3 ), std::runtime_error );
+    BOOST_REQUIRE_THROW( cipher.decrypt( ct3, aad1 ), std::runtime_error );
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 

--- a/threshold_encryption/ThresholdEncryption.cpp
+++ b/threshold_encryption/ThresholdEncryption.cpp
@@ -152,8 +152,9 @@ std::vector< bool > ThresholdEncryption::validateEncryptionBatch(
         return {};
     }
 
-    if ( _associatedDataTE && _associatedDataTE->size() != _ciphertexts.size() ) {
-        throw ThresholdUtils::IncorrectInput( "Associated data TE size does not match" );
+    // Allow partial AAD: first N AADs apply to first N ciphertexts, rest have no AAD
+    if ( _associatedDataTE && _associatedDataTE->size() > _ciphertexts.size() ) {
+        throw ThresholdUtils::IncorrectInput( "Associated data TE size cannot exceed ciphertexts size" );
     }
 
     // Store concrete values (no reference_wrapper)
@@ -171,8 +172,9 @@ std::vector< bool > ThresholdEncryption::validateEncryptionBatch(
 
     for ( size_t i = 0; i < size; ++i ) {
         const auto& [U, V, W] = _ciphertexts.at( i );
+        // Apply AAD only if provided and within AAD vector bounds
         const std::vector< uint8_t >* aadPtr =
-            _associatedDataTE ? &_associatedDataTE->at( i ) : nullptr;
+            ( _associatedDataTE && i < _associatedDataTE->size() ) ? &_associatedDataTE->at( i ) : nullptr;
         const algebra::G1Point H = TE::HashToGroup( U, V, aadPtr );
 
         g1P1s.at( i ) = W;
@@ -192,21 +194,28 @@ std::vector< bool > ThresholdEncryption::validateEncryptionBatchParallel(
         return {};
     }
 
-    if ( _associatedDataTE && _associatedDataTE->size() != _ciphertexts.size() ) {
-        throw ThresholdUtils::IncorrectInput( "Associated data TE size does not match" );
+    // Allow partial AAD: first N AADs apply to first N ciphertexts, rest have no AAD
+    if ( _associatedDataTE && _associatedDataTE->size() > _ciphertexts.size() ) {
+        throw ThresholdUtils::IncorrectInput( "Associated data TE size cannot exceed ciphertexts size" );
     }
 
     auto result = ThresholdUtils::executeInParallel< bool >(
         _ciphertexts.size(), [&_ciphertexts, _associatedDataTE]( size_t startIdx, size_t endIdx ) {
             const std::vector< CipheredKey > subset(
                 _ciphertexts.begin() + startIdx, _ciphertexts.begin() + endIdx );
-            // Slice AAD vector for this subset
+            // Slice AAD vector for this subset - handle partial AAD
             const std::vector< std::vector< uint8_t > >* aadSubset = nullptr;
             std::vector< std::vector< uint8_t > > aadSubsetStorage;
             if ( _associatedDataTE ) {
-                aadSubsetStorage.assign(
-                    _associatedDataTE->begin() + startIdx, _associatedDataTE->begin() + endIdx );
-                aadSubset = &aadSubsetStorage;
+                // Only include AAD entries that are within bounds
+                size_t aadSize = _associatedDataTE->size();
+                size_t aadStart = std::min( startIdx, aadSize );
+                size_t aadEnd = std::min( endIdx, aadSize );
+                if ( aadStart < aadEnd ) {
+                    aadSubsetStorage.assign(
+                        _associatedDataTE->begin() + aadStart, _associatedDataTE->begin() + aadEnd );
+                    aadSubset = &aadSubsetStorage;
+                }
             }
             return ThresholdEncryption::validateEncryptionBatch( subset, aadSubset );
         } );
@@ -279,9 +288,10 @@ std::vector< bool > ThresholdEncryption::validateDecryptionSharesBatchParallel(
             "Decryption shares size must be multiple of ciphertexts size" );
     }
 
-    if ( _associatedDataTE && _associatedDataTE->size() != _cipherTexts.size() ) {
+    // Allow partial AAD: first N AADs apply to first N ciphertexts, rest have no AAD
+    if ( _associatedDataTE && _associatedDataTE->size() > _cipherTexts.size() ) {
         throw ThresholdUtils::IncorrectInput(
-            "Associated data size must match number of ciphertexts" );
+            "Associated data size cannot exceed number of ciphertexts" );
     }
 
     size_t sharesPerCiphertext = _decryptionShares.size() / _cipherTexts.size();
@@ -298,13 +308,19 @@ std::vector< bool > ThresholdEncryption::validateDecryptionSharesBatchParallel(
                 _publicKeys.begin() + startIdx * sharesPerCiphertext,
                 _publicKeys.begin() + endIdx * sharesPerCiphertext );
 
-            // Slice AAD for this subset
+            // Slice AAD for this subset - handle partial AAD
             const std::vector< std::vector< uint8_t > >* aadSubset = nullptr;
             std::vector< std::vector< uint8_t > > aadSubsetStorage;
             if ( _associatedDataTE ) {
-                aadSubsetStorage.assign(
-                    _associatedDataTE->begin() + startIdx, _associatedDataTE->begin() + endIdx );
-                aadSubset = &aadSubsetStorage;
+                // Only include AAD entries that are within bounds
+                size_t aadSize = _associatedDataTE->size();
+                size_t aadStart = std::min( startIdx, aadSize );
+                size_t aadEnd = std::min( endIdx, aadSize );
+                if ( aadStart < aadEnd ) {
+                    aadSubsetStorage.assign(
+                        _associatedDataTE->begin() + aadStart, _associatedDataTE->begin() + aadEnd );
+                    aadSubset = &aadSubsetStorage;
+                }
             }
 
             return ThresholdEncryption::validateDecryptionSharesBatch(

--- a/threshold_encryption/ThresholdEncryption.cpp
+++ b/threshold_encryption/ThresholdEncryption.cpp
@@ -154,7 +154,8 @@ std::vector< bool > ThresholdEncryption::validateEncryptionBatch(
 
     // Allow partial AAD: first N AADs apply to first N ciphertexts, rest have no AAD
     if ( _associatedDataTE && _associatedDataTE->size() > _ciphertexts.size() ) {
-        throw ThresholdUtils::IncorrectInput( "Associated data TE size cannot exceed ciphertexts size" );
+        throw ThresholdUtils::IncorrectInput(
+            "Associated data TE size cannot exceed ciphertexts size" );
     }
 
     // Store concrete values (no reference_wrapper)
@@ -174,7 +175,8 @@ std::vector< bool > ThresholdEncryption::validateEncryptionBatch(
         const auto& [U, V, W] = _ciphertexts.at( i );
         // Apply AAD only if provided and within AAD vector bounds
         const std::vector< uint8_t >* aadPtr =
-            ( _associatedDataTE && i < _associatedDataTE->size() ) ? &_associatedDataTE->at( i ) : nullptr;
+            ( _associatedDataTE && i < _associatedDataTE->size() ) ? &_associatedDataTE->at( i ) :
+                                                                     nullptr;
         const algebra::G1Point H = TE::HashToGroup( U, V, aadPtr );
 
         g1P1s.at( i ) = W;
@@ -196,7 +198,8 @@ std::vector< bool > ThresholdEncryption::validateEncryptionBatchParallel(
 
     // Allow partial AAD: first N AADs apply to first N ciphertexts, rest have no AAD
     if ( _associatedDataTE && _associatedDataTE->size() > _ciphertexts.size() ) {
-        throw ThresholdUtils::IncorrectInput( "Associated data TE size cannot exceed ciphertexts size" );
+        throw ThresholdUtils::IncorrectInput(
+            "Associated data TE size cannot exceed ciphertexts size" );
     }
 
     auto result = ThresholdUtils::executeInParallel< bool >(
@@ -212,8 +215,8 @@ std::vector< bool > ThresholdEncryption::validateEncryptionBatchParallel(
                 size_t aadStart = std::min( startIdx, aadSize );
                 size_t aadEnd = std::min( endIdx, aadSize );
                 if ( aadStart < aadEnd ) {
-                    aadSubsetStorage.assign(
-                        _associatedDataTE->begin() + aadStart, _associatedDataTE->begin() + aadEnd );
+                    aadSubsetStorage.assign( _associatedDataTE->begin() + aadStart,
+                        _associatedDataTE->begin() + aadEnd );
                     aadSubset = &aadSubsetStorage;
                 }
             }
@@ -317,8 +320,8 @@ std::vector< bool > ThresholdEncryption::validateDecryptionSharesBatchParallel(
                 size_t aadStart = std::min( startIdx, aadSize );
                 size_t aadEnd = std::min( endIdx, aadSize );
                 if ( aadStart < aadEnd ) {
-                    aadSubsetStorage.assign(
-                        _associatedDataTE->begin() + aadStart, _associatedDataTE->begin() + aadEnd );
+                    aadSubsetStorage.assign( _associatedDataTE->begin() + aadStart,
+                        _associatedDataTE->begin() + aadEnd );
                     aadSubset = &aadSubsetStorage;
                 }
             }

--- a/threshold_encryption/ThresholdEncryption.h
+++ b/threshold_encryption/ThresholdEncryption.h
@@ -139,7 +139,9 @@ public:
      * `TEPublicKeyShare` each.
      * @param _decryptionShares Vector of decryption shares. Must be same size as _publicKeys.
      * @param _publicKeys Vector of public keys corresponding to the decryption shares.
-     * @param _associatedDataTE Optional vector of TE AAD - one per ciphertext
+     * @param _associatedDataTE Optional vector of associated data. Supports partial AAD:
+     * if size < ciphertexts size, first N AADs apply to first N ciphertexts, remaining
+     * ciphertexts are validated without AAD. Empty AAD entries are treated as no AAD.
      * @return Vec of bools, each idx specifying if it was successfully validated or not.
      * Each idx corresponds to the same idx on _decryptionShares and _publicKeys.
      */

--- a/threshold_encryption/ThresholdEncryption.h
+++ b/threshold_encryption/ThresholdEncryption.h
@@ -80,7 +80,9 @@ public:
      * @brief Validates a batch of TE ciphered keys. Same as above, but more performant
      * @param _ciphertexts Vector of encrypted AESKeys used to encrypt the message held by
      * Ciphertext struct
-     * @param _associatedDataTE Optional vector of associated data - one AAD per ciphertext
+     * @param _associatedDataTE Optional vector of associated data. Supports partial AAD:
+     * if size < ciphertexts size, first N AADs apply to first N ciphertexts, remaining
+     * ciphertexts are validated without AAD. Empty AAD entries are treated as no AAD.
      * @return Vec of bools, each idx specifying if it was successfully validated or not.
      * Each idx corresponds to the same idx on _ciphertexts.
      */
@@ -92,7 +94,9 @@ public:
      * @brief Validates a batch of TE ciphered keys in parallel. Same as above, but multi-threaded
      * @param _ciphertexts Vector of encrypted AESKeys used to encrypt the message held by
      * Ciphertext struct
-     * @param _associatedDataTE Optional vector of associated data - one AAD per ciphertext
+     * @param _associatedDataTE Optional vector of associated data. Supports partial AAD:
+     * if size < ciphertexts size, first N AADs apply to first N ciphertexts, remaining
+     * ciphertexts are validated without AAD. Empty AAD entries are treated as no AAD.
      * @return Vec of bools, each idx specifying if it was successfully validated or not
      */
     static std::vector< bool > validateEncryptionBatchParallel(

--- a/threshold_encryption/threshold_encryption.cpp
+++ b/threshold_encryption/threshold_encryption.cpp
@@ -351,9 +351,10 @@ std::vector< bool > TE::VerifyBatch( const std::vector< CipheredKey >& ciphertex
             "decryption shares and public keys must have same size" );
     }
 
-    if ( associatedDataTE && associatedDataTE->size() != numberOfBatches ) {
+    // Allow partial AAD: first N AADs apply to first N ciphertexts, rest have no AAD
+    if ( associatedDataTE && associatedDataTE->size() > numberOfBatches ) {
         throw ThresholdUtils::IncorrectInput(
-            "associated data size must match number of ciphertexts" );
+            "associated data size cannot exceed number of ciphertexts" );
     }
 
     std::vector< algebra::G1Point > g1P1s;
@@ -363,8 +364,10 @@ std::vector< bool > TE::VerifyBatch( const std::vector< CipheredKey >& ciphertex
 
     for ( size_t i = 0; i < ciphertexts.size(); ++i ) {
         const auto& [U, V, W] = ciphertexts[i];
+        // Apply AAD only if provided and within AAD vector bounds
         const std::vector< uint8_t >* aadPtr =
-            associatedDataTE ? &associatedDataTE->at( i ) : nullptr;
+            ( associatedDataTE && i < associatedDataTE->size() ) ? &associatedDataTE->at( i ) :
+                                                                   nullptr;
 
         algebra::G1Point H = HashToGroup( U, V, aadPtr );
         // no need to validate H - assumes H has been validated already when performing the


### PR DESCRIPTION
## Description

- AAD TE API now allows AAD data to not be equal to the number of ciphertexts:
   - In such cases, use 1 AAD for each ciphertext until no AAD left to use.
   - Then use no AAD.
   - Easier for caller to do entire validation in 1 go
   
   Fixes #287 