### PR TITLE
Bite ts 37/optimize t encrypt

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,6 +78,7 @@ jobs:
         export CC=gcc-11
         export CXX=g++-11
         export TARGET=all
+        export CMAKE_BUILD_TYPE=Release
         cd deps
         ./clean.sh
         ./build.sh WITH_EMSCRIPTEN=1
@@ -92,7 +93,7 @@ jobs:
         cd ../..
         mkdir -p build_em && cd build_em
         export LIBRARIES_ROOT=../deps/deps_inst/wasm32-emscripten/lib
-        emcmake cmake -DEMSCRIPTEN=ON -DBUILD_TESTS=OFF -DGMP_LIBRARY="$LIBRARIES_ROOT"/libgmp.a -DCRYPTOPP_LIBRARY="$LIBRARIES_ROOT"/libcrypto.a -DGMPXX_LIBRARY="$LIBRARIES_ROOT"/libgmpxx.a ..
+        emcmake cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DEMSCRIPTEN=ON -DBUILD_TESTS=OFF -DGMP_LIBRARY="$LIBRARIES_ROOT"/libgmp.a -DCRYPTOPP_LIBRARY="$LIBRARIES_ROOT"/libcrypto.a -DGMPXX_LIBRARY="$LIBRARIES_ROOT"/libgmpxx.a ..
         emmake make -j$(nproc)
         cd ..
         cp build_em/threshold_encryption/encrypt.* node/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,7 @@ jobs:
         cd ../..
         mkdir -p build_em && cd build_em
         export LIBRARIES_ROOT=../deps/deps_inst/wasm32-emscripten/lib
-        emcmake cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DEMSCRIPTEN=ON -DBUILD_TESTS=OFF -DGMP_LIBRARY="$LIBRARIES_ROOT"/libgmp.a -DCRYPTOPP_LIBRARY="$LIBRARIES_ROOT"/libcrypto.a -DGMPXX_LIBRARY="$LIBRARIES_ROOT"/libgmpxx.a ..
+        emcmake cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DEMSCRIPTEN=ON -DBUILD_TESTS=OFF -DGMP_LIBRARY="$LIBRARIES_ROOT"/libgmp.a -DCRYPTOPP_LIBRARY="$LIBRARIES_ROOT"/libcrypto.a -DGMPXX_LIBRARY="$LIBRARIES_ROOT"/libgmpxx.a ..
         emmake make -j$(nproc)
         cd ..
         cp build_em/threshold_encryption/encrypt.* node/

--- a/node/EncryptMessage.mjs
+++ b/node/EncryptMessage.mjs
@@ -1,0 +1,32 @@
+import ModuleFactory from './encrypt.js';
+
+export async function encryptMessage(txData, publicKey, aadTE = '', aadAES = '') {
+    const Module = await ModuleFactory();
+    return Module.ccall(
+        'encryptMessage', // Name of the exported C++ function
+        'string',         // Return type
+        ['string', 'string', 'string', 'string'], // Argument types
+        [txData, publicKey, aadTE, aadAES] // Arguments
+    );
+}
+
+export async function encryptMessageDualKey(
+    txData, firstPublicKey, secondPublicKey, aadTE = '', aadAES = '') {
+    const Module = await ModuleFactory();
+    return Module.ccall(
+        'encryptMessageDualKey', // Name of the exported C++ function
+        'string',         // Return type
+        ['string', 'string', 'string', 'string', 'string'], // Argument types
+        [txData, firstPublicKey, secondPublicKey, aadTE, aadAES] // Arguments
+    );
+}
+
+export async function encryptMessageMockup(txData) {
+    const Module = await ModuleFactory();
+    return Module.ccall(
+        'encryptMessageMockup', // Name of the exported C++ function
+        'string',         // Return type
+        ['string'], // Argument types
+        [txData] // Arguments
+    );
+}

--- a/node/package.json
+++ b/node/package.json
@@ -29,8 +29,17 @@
   },
   "description": "A Node.js module to encrypt messages using WebAssembly",
   "main": "EncryptMessage.js",
+  "module": "EncryptMessage.mjs",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./EncryptMessage.mjs",
+      "require": "./EncryptMessage.js"
+    }
+  },
   "files": [
     "EncryptMessage.js",
+    "EncryptMessage.mjs",
     "encrypt.js",
     "encrypt.wasm"
   ]

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skalenetwork/t-encrypt",
-  "version": "0.7.0",
+  "version": "0.8.0",
 
   "keywords": [
     "SKALE",


### PR DESCRIPTION
fixes https://github.com/skalenetwork/bite-ts/issues/37

decrease encrypt.js size from 5.8 mb to 2.7 mb

update `t-encrypt` package exports to make it tree-shakable