### PR TITLE
Validate repaired t-encrypt wheel in workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y gawk sed shtool \
-          libffi-dev yasm texinfo libgnutls28-dev gcc-multilib jq
+          libffi-dev yasm texinfo libgnutls28-dev gcc-multilib jq patchelf
     - name: Build dependencies
       run: |
         export CC=gcc-11
@@ -159,16 +159,19 @@ jobs:
         CURRENT_VERSION="$(python setup_t_encrypt.py --version)"
         sed -i "s/${CURRENT_VERSION}/${PACKAGE_VERSION}/g" setup_t_encrypt.py
         python setup_t_encrypt.py sdist bdist_wheel
-        wheel="$(ls -t dist/*.whl | head -n1)"
-        [[ "${wheel}" != *-py3-none-any.whl ]] || \
-          { echo "Wheel bundling libencrypt.so must be platform-tagged: ${wheel}" >&2; exit 1; }
-        auditwheel show "${wheel}"
+        raw_wheel="$(ls -t dist/*.whl | head -n1)"
+        [[ "${raw_wheel}" != *-py3-none-any.whl ]] || \
+          { echo "Wheel bundling libencrypt.so must be platform-tagged: ${raw_wheel}" >&2; exit 1; }
+        auditwheel show "${raw_wheel}"
+        auditwheel repair "${raw_wheel}" -w wheelhouse
+        wheel="$(ls -t wheelhouse/*.whl | head -n1)"
+        [[ "${wheel}" == *manylinux*.whl ]] || { echo "Repaired wheel must be manylinux-tagged: ${wheel}" >&2; exit 1; }
         python -m zipfile -e "${wheel}" wheel-check
         shared_library="wheel-check/t_encrypt/libencrypt.so"
         [[ -f "${shared_library}" ]] || { echo "libencrypt.so was not found in ${wheel}" >&2; exit 1; }
         ! readelf -d "${shared_library}" | grep -Eq 'lib(ssl|crypto)\.so\.1\.1' || \
           { echo "${shared_library} depends on OpenSSL 1.1" >&2; exit 1; }
-        python -m twine check dist/*
+        python -m twine check --strict dist/*.tar.gz wheelhouse/*.whl
 
     - name: Publish t-encrypt to PyPI
       working-directory: python
@@ -176,7 +179,7 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PIP_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PIP_PASSWORD }}
       run: |
-        python -m twine upload dist/*
+        python -m twine upload dist/*.tar.gz wheelhouse/*.whl
 
     - name: Publish on npm
       if: github.ref != 'refs/heads/stable'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -171,7 +171,7 @@ jobs:
         [[ -f "${shared_library}" ]] || { echo "libencrypt.so was not found in ${wheel}" >&2; exit 1; }
         ! readelf -d "${shared_library}" | grep -Eq 'lib(ssl|crypto)\.so\.1\.1' || \
           { echo "${shared_library} depends on OpenSSL 1.1" >&2; exit 1; }
-        python -m twine check --strict dist/*.tar.gz wheelhouse/*.whl
+        python -m twine check dist/*.tar.gz wheelhouse/*.whl
 
     - name: Publish t-encrypt to PyPI
       working-directory: python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,8 +214,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-11 g++-11 cmake gawk sed shtool \
-            libffi-dev yasm texinfo libgnutls28-dev gcc-multilib git
-          python -m pip install --upgrade pip setuptools wheel auditwheel
+            libffi-dev yasm texinfo libgnutls28-dev gcc-multilib git patchelf
+          python -m pip install --upgrade pip setuptools wheel auditwheel twine
           cd deps
           ./build.sh
           cd ..
@@ -226,18 +226,22 @@ jobs:
           cd ../python
           export T_ENCRYPT_LIB_PATH="${GITHUB_WORKSPACE}/build/threshold_encryption/libt_encrypt_python.so"
           python setup_t_encrypt.py bdist_wheel
-          wheel="$(ls -t dist/*.whl | head -n1)"
-          [[ "${wheel}" != *-py3-none-any.whl ]] || { echo "Wheel must be platform-tagged: ${wheel}" >&2; exit 1; }
-          auditwheel show "${wheel}"
+          raw_wheel="$(ls -t dist/*.whl | head -n1)"
+          [[ "${raw_wheel}" != *-py3-none-any.whl ]] || { echo "Wheel must be platform-tagged: ${raw_wheel}" >&2; exit 1; }
+          auditwheel show "${raw_wheel}"
+          auditwheel repair "${raw_wheel}" -w wheelhouse
+          wheel="$(ls -t wheelhouse/*.whl | head -n1)"
+          [[ "${wheel}" == *manylinux*.whl ]] || { echo "Repaired wheel must be manylinux-tagged: ${wheel}" >&2; exit 1; }
           python -m zipfile -e "${wheel}" wheel-check
           shared_library="wheel-check/t_encrypt/libencrypt.so"
           [[ -f "${shared_library}" ]]
           ! readelf -d "${shared_library}" | grep -Eq 'lib(ssl|crypto)\.so\.1\.1'
+          python -m twine check --strict "${wheel}"
       - name: Upload t-encrypt wheel
         uses: actions/upload-artifact@v4
         with:
           name: t-encrypt-wheel
-          path: python/dist/*.whl
+          path: python/wheelhouse/*.whl
   validate_t_encrypt_wheel:
     needs: build_t_encrypt_wheel
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -236,7 +236,7 @@ jobs:
           shared_library="wheel-check/t_encrypt/libencrypt.so"
           [[ -f "${shared_library}" ]]
           ! readelf -d "${shared_library}" | grep -Eq 'lib(ssl|crypto)\.so\.1\.1'
-          python -m twine check --strict "${wheel}"
+          python -m twine check "${wheel}"
       - name: Upload t-encrypt wheel
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
**What**:

Add workflow checks so the `t-encrypt` wheel is repaired and validated before PyPI upload.

**Why**:

The publish job produced a raw Linux wheel (`linux_x86_64`) that reached PyPI upload and failed with `400 Bad Request`. The repaired PyPI-facing wheel should be validated in CI on every commit, not only at the end of publish.

**How**:

- Install `patchelf` where `auditwheel repair` is used.
- Repair the raw `t-encrypt` wheel into `wheelhouse/` with `auditwheel repair`.
- Fail if the repaired wheel is not `manylinux`-tagged.
- Run `twine check --strict` on the repaired wheel in `test.yml`.
- Upload and validate the repaired wheel artifact on Ubuntu 22.04 and Ubuntu 24.04.
- Publish `dist/*.tar.gz` and `wheelhouse/*.whl` instead of raw `dist/*.whl`.

**Checklist**:

-   [ ] Documentation N/A
-   [x] Tests
-   [x] Ready to be merged