### PR TITLE
Harden input validation and RNG error handling across libBLS

### DIFF
--- a/backends/interface/functions.cpp
+++ b/backends/interface/functions.cpp
@@ -65,8 +65,8 @@ G1Point hashToG1( const std::string& message ) {
     auto hash_bytes_arr = std::array< uint8_t, HASH_SIZE >();
 
     uint64_t bin_len;
-    if ( !ThresholdUtils::hex2carray( message.c_str(), &bin_len, hash_bytes_arr.data(),
-             hash_bytes_arr.size() ) ) {
+    if ( !ThresholdUtils::hex2carray(
+             message.c_str(), &bin_len, hash_bytes_arr.data(), hash_bytes_arr.size() ) ) {
         throw std::runtime_error( "Invalid hash" );
     }
 

--- a/backends/interface/functions.cpp
+++ b/backends/interface/functions.cpp
@@ -58,14 +58,15 @@ G1Point hashToG1( const std::array< uint8_t, HASH_SIZE >& hash_byte_arr ) {
 }
 
 G1Point hashToG1( const std::string& message ) {
-    auto hash_bytes_arr = std::array< uint8_t, HASH_SIZE >();
-
-    if ( message.length() > HASH_SIZE * 2 ) {
-        throw std::runtime_error( "Hash string too long" );
+    if ( message.length() != HASH_SIZE * 2 ) {
+        throw std::runtime_error( "Hash string has incorrect length" );
     }
 
+    auto hash_bytes_arr = std::array< uint8_t, HASH_SIZE >();
+
     uint64_t bin_len;
-    if ( !ThresholdUtils::hex2carray( message.c_str(), &bin_len, hash_bytes_arr.data() ) ) {
+    if ( !ThresholdUtils::hex2carray( message.c_str(), &bin_len, hash_bytes_arr.data(),
+             hash_bytes_arr.size() ) ) {
         throw std::runtime_error( "Invalid hash" );
     }
 

--- a/bls/bls.cpp
+++ b/bls/bls.cpp
@@ -62,7 +62,8 @@ algebra::G1Point Bls::HashPublicKeyToG1( const algebra::G2Point& elem ) {
     auto hash_bytes_arr = std::array< uint8_t, 32 >();
 
     uint64_t bin_len;
-    if ( !ThresholdUtils::hex2carray( hashed_pubkey.c_str(), &bin_len, hash_bytes_arr.data() ) ) {
+    if ( !ThresholdUtils::hex2carray(
+             hashed_pubkey.c_str(), &bin_len, hash_bytes_arr.data(), hash_bytes_arr.size() ) ) {
         throw std::runtime_error( "Invalid hash" );
     }
 
@@ -81,7 +82,8 @@ std::pair< algebra::G1Point, std::string > Bls::HashPublicKeyToG1WithHint(
     auto hash_bytes_arr = std::array< uint8_t, 32 >();
 
     uint64_t bin_len;
-    if ( !ThresholdUtils::hex2carray( hashed_pubkey.c_str(), &bin_len, hash_bytes_arr.data() ) ) {
+    if ( !ThresholdUtils::hex2carray(
+             hashed_pubkey.c_str(), &bin_len, hash_bytes_arr.data(), hash_bytes_arr.size() ) ) {
         throw std::runtime_error( "Invalid hash" );
     }
 

--- a/test/test_bls.cpp
+++ b/test/test_bls.cpp
@@ -116,12 +116,14 @@ std::array< uint8_t, 32 > GenerateRandHash() {
     return hash_byte_arr;
 }
 
+// Generates a random hex string representing 32 bytes (HASH_SIZE), i.e. 64 hex characters -
+// hashToG1(const std::string&) requires an exact match against HASH_SIZE * 2.
 std::string rand32HexStr() {
     std::array< char, 16 > s = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c',
         'd', 'e', 'f' };
 
     std::string res = "";
-    for ( size_t i = 0; i < 32; ++i ) {
+    for ( size_t i = 0; i < 64; ++i ) {
         res.push_back( *( s.begin() + rand_gen() % 16 ) );
     }
 

--- a/test/unit_tests_bls.cpp
+++ b/test/unit_tests_bls.cpp
@@ -44,12 +44,13 @@ std::default_random_engine rand_gen( ( unsigned int ) time( 0 ) );
 
 BOOST_TEST_GLOBAL_CONFIGURATION( GlobalConfig );
 
+// Generates a random hex string representing 32 bytes (HASH_SIZE), i.e. 64 hex characters
 std::string rand32HexStr() {
     std::array< char, 16 > s = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c',
         'd', 'e', 'f' };
 
     std::string res = "";
-    for ( size_t i = 0; i < 32; ++i ) {
+    for ( size_t i = 0; i < 64; ++i ) {
         res.push_back( *( s.begin() + rand_gen() % 16 ) );
     }
 

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -44,7 +44,9 @@ std::string randomHexaString( size_t length ) {
 
 std::vector< uint8_t > randomByteVec( size_t length ) {
     std::vector< uint8_t > bytes( length );
-    RAND_bytes( bytes.data(), length );
+    if ( RAND_bytes( bytes.data(), length ) != 1 ) {
+        throw std::runtime_error( "Failed to generate random bytes" );
+    }
     return bytes;
 }
 

--- a/test/utils.h
+++ b/test/utils.h
@@ -40,7 +40,9 @@ std::string randomHexaString( size_t length );
 template < size_t N >
 std::array< uint8_t, N > randomByteArray() {
     std::array< uint8_t, N > bytes;
-    RAND_bytes( bytes.data(), N );
+    if ( RAND_bytes( bytes.data(), N ) != 1 ) {
+        throw std::runtime_error( "Failed to generate random bytes" );
+    }
     return bytes;
 }
 

--- a/test/utils.h
+++ b/test/utils.h
@@ -6,7 +6,10 @@
 #include <threshold_encryption/TEPrivateKeyShare.h>
 #include <threshold_encryption/TEPublicKey.h>
 #include <threshold_encryption/TEPublicKeyShare.h>
+#include <openssl/rand.h>
+#include <array>
 #include <chrono>
+#include <stdexcept>
 
 #define TIMER( variable, code_block )                                                   \
     auto start_##variable = std::chrono::high_resolution_clock::now();                  \

--- a/test/utils.h
+++ b/test/utils.h
@@ -2,11 +2,11 @@
 #define UTILS_H
 
 #include "backends/algebra.hpp"
+#include <openssl/rand.h>
 #include <threshold_encryption/TEPrivateKey.h>
 #include <threshold_encryption/TEPrivateKeyShare.h>
 #include <threshold_encryption/TEPublicKey.h>
 #include <threshold_encryption/TEPublicKeyShare.h>
-#include <openssl/rand.h>
 #include <array>
 #include <chrono>
 #include <stdexcept>

--- a/threshold_encryption/AesGcmCipher.cpp
+++ b/threshold_encryption/AesGcmCipher.cpp
@@ -130,7 +130,7 @@ std::vector< uint8_t > AesGcmCipher::encrypt(
         std::copy( hmacResult, hmacResult + AES_GCM_IV_SIZE, localIv );
         ++encryptCounter;
     } else {
-        if ( RAND_bytes( localIv, AES_GCM_IV_SIZE ) != 1) {
+        if ( RAND_bytes( localIv, AES_GCM_IV_SIZE ) != 1 ) {
             throw std::runtime_error( "Failed to generate random IV" );
         }
     }

--- a/threshold_encryption/AesGcmCipher.cpp
+++ b/threshold_encryption/AesGcmCipher.cpp
@@ -130,7 +130,9 @@ std::vector< uint8_t > AesGcmCipher::encrypt(
         std::copy( hmacResult, hmacResult + AES_GCM_IV_SIZE, localIv );
         ++encryptCounter;
     } else {
-        RAND_bytes( localIv, AES_GCM_IV_SIZE );
+        if ( RAND_bytes( localIv, AES_GCM_IV_SIZE ) != 1) {
+            throw std::runtime_error( "Failed to generate random IV" );
+        }
     }
     // Place IV at start of output
     std::copy( localIv, localIv + AES_GCM_IV_SIZE, output.begin() );

--- a/threshold_encryption/CipheredKey.cpp
+++ b/threshold_encryption/CipheredKey.cpp
@@ -58,7 +58,9 @@ void CipheredKey::validate() const {
 CipheredKey CipheredKey::random() {
     algebra::G2Point U = algebra::G2Point::random();
     AES256Key V;
-    RAND_bytes( V.data(), V.size() );
+    if (RAND_bytes( V.data(), V.size() ) != 1) {
+        throw std::runtime_error( "Failed to generate random AES key" );
+    }
     algebra::G1Point W = algebra::G1Point::random();
     return CipheredKey( U, V, W );
 }

--- a/threshold_encryption/CipheredKey.cpp
+++ b/threshold_encryption/CipheredKey.cpp
@@ -58,7 +58,7 @@ void CipheredKey::validate() const {
 CipheredKey CipheredKey::random() {
     algebra::G2Point U = algebra::G2Point::random();
     AES256Key V;
-    if (RAND_bytes( V.data(), V.size() ) != 1) {
+    if ( RAND_bytes( V.data(), V.size() ) != 1 ) {
         throw std::runtime_error( "Failed to generate random AES key" );
     }
     algebra::G1Point W = algebra::G1Point::random();

--- a/tools/hash_g1.cpp
+++ b/tools/hash_g1.cpp
@@ -54,7 +54,7 @@ void hash_g1( const size_t t, const size_t n ) {
     } else {
         uint64_t bin_len;
         if ( !libBLS::ThresholdUtils::hex2carray(
-                 to_be_hashed.c_str(), &bin_len, hash_bytes_arr->data() ) ) {
+                 to_be_hashed.c_str(), &bin_len, hash_bytes_arr->data(), hash_bytes_arr->size() ) ) {
             throw std::runtime_error( "Invalid hash" );
         }
     }

--- a/tools/hash_g1.cpp
+++ b/tools/hash_g1.cpp
@@ -53,8 +53,8 @@ void hash_g1( const size_t t, const size_t n ) {
         }
     } else {
         uint64_t bin_len;
-        if ( !libBLS::ThresholdUtils::hex2carray(
-                 to_be_hashed.c_str(), &bin_len, hash_bytes_arr->data(), hash_bytes_arr->size() ) ) {
+        if ( !libBLS::ThresholdUtils::hex2carray( to_be_hashed.c_str(), &bin_len,
+                 hash_bytes_arr->data(), hash_bytes_arr->size() ) ) {
             throw std::runtime_error( "Invalid hash" );
         }
     }

--- a/tools/sign_bls.cpp
+++ b/tools/sign_bls.cpp
@@ -37,33 +37,6 @@ static bool g_b_verbose_mode = false;
 
 static bool g_b_rehash = false;
 
-int char2int( char _input ) {
-    if ( _input >= '0' && _input <= '9' )
-        return _input - '0';
-    if ( _input >= 'A' && _input <= 'F' )
-        return _input - 'A' + 10;
-    if ( _input >= 'a' && _input <= 'f' )
-        return _input - 'a' + 10;
-    return -1;
-}
-
-bool hex2carray( const char* _hex, uint64_t* _bin_len, uint8_t* _bin ) {
-    int len = strnlen( _hex, 2 * 1024 );
-
-    if ( len == 0 && len % 2 == 1 )
-        return false;
-    *_bin_len = len / 2;
-    for ( int i = 0; i < len / 2; i++ ) {
-        int high = char2int( ( char ) _hex[i * 2] );
-        int low = char2int( ( char ) _hex[i * 2 + 1] );
-        if ( high < 0 || low < 0 ) {
-            return false;
-        }
-        _bin[i] = ( unsigned char ) ( high * 16 + low );
-    }
-    return true;
-}
-
 void Sign( const size_t t, const size_t n, std::istream& data_file, std::ostream& outfile,
     const std::string& key, bool sign_all = true, int idx = -1 ) {
     libBLS::Bls bls_instance = libBLS::Bls( t, n );
@@ -83,7 +56,8 @@ void Sign( const size_t t, const size_t n, std::istream& data_file, std::ostream
         }
     } else {
         uint64_t bin_len;
-        if ( !hex2carray( message.c_str(), &bin_len, hash_bytes_arr->data() ) ) {
+        if ( !libBLS::ThresholdUtils::hex2carray(
+                 message.c_str(), &bin_len, hash_bytes_arr->data(), hash_bytes_arr->size() ) ) {
             throw std::runtime_error( "Invalid hash" );
         }
     }

--- a/tools/utils.cpp
+++ b/tools/utils.cpp
@@ -144,21 +144,33 @@ int ThresholdUtils::char2int( char _input ) {
     return -1;
 }
 
-bool ThresholdUtils::hex2carray( const char* _hex, uint64_t* _bin_len, uint8_t* _bin ) {
+bool ThresholdUtils::hex2carray( const char* _hex, uint64_t* _bin_written_len, uint8_t* _bin, uint64_t _bin_capacity ) {
+    if ( _hex == nullptr || _bin_written_len == nullptr || _bin == nullptr ) {
+        return false;
+    }
     int len = strnlen( _hex, 2 * 1024 );
 
     if ( len % 2 == 1 ) {
         return false;
     }
-    *_bin_len = len / 2;
-    for ( int i = 0; i < len / 2; i++ ) {
-        int high = char2int( ( char ) _hex[i * 2] );
-        int low = char2int( ( char ) _hex[i * 2 + 1] );
+
+    unsigned int byte_length = len / 2;
+
+    if ( byte_length != _bin_capacity ) {
+        return false;
+    }
+
+    *_bin_written_len = 0;
+
+    for ( unsigned int i = 0; i < byte_length; i++ ) {
+        int high = char2int( _hex[i * 2] );
+        int low = char2int( _hex[i * 2 + 1] );
         if ( high < 0 || low < 0 ) {
             return false;
         }
         _bin[i] = ( unsigned char ) ( high * 16 + low );
     }
+    *_bin_written_len = byte_length;
     return true;
 }
 

--- a/tools/utils.cpp
+++ b/tools/utils.cpp
@@ -144,7 +144,8 @@ int ThresholdUtils::char2int( char _input ) {
     return -1;
 }
 
-bool ThresholdUtils::hex2carray( const char* _hex, uint64_t* _bin_written_len, uint8_t* _bin, uint64_t _bin_capacity ) {
+bool ThresholdUtils::hex2carray(
+    const char* _hex, uint64_t* _bin_written_len, uint8_t* _bin, uint64_t _bin_capacity ) {
     if ( _hex == nullptr || _bin_written_len == nullptr || _bin == nullptr ) {
         return false;
     }

--- a/tools/utils.h
+++ b/tools/utils.h
@@ -121,7 +121,7 @@ public:
 
     static std::string carray2Hex( const unsigned char* d, uint64_t len );
 
-    static bool hex2carray( const char* _hex, uint64_t* _bin_len, uint8_t* _bin );
+    static bool hex2carray( const char* _hex, uint64_t* _bin_written_len, uint8_t* _bin, uint64_t _bin_capacity );
 
     static std::shared_ptr< std::vector< std::string > > SplitString(
         const std::string& str, const std::string& delim );

--- a/tools/utils.h
+++ b/tools/utils.h
@@ -121,7 +121,8 @@ public:
 
     static std::string carray2Hex( const unsigned char* d, uint64_t len );
 
-    static bool hex2carray( const char* _hex, uint64_t* _bin_written_len, uint8_t* _bin, uint64_t _bin_capacity );
+    static bool hex2carray(
+        const char* _hex, uint64_t* _bin_written_len, uint8_t* _bin, uint64_t _bin_capacity );
 
     static std::shared_ptr< std::vector< std::string > > SplitString(
         const std::string& str, const std::string& delim );

--- a/tools/verify_bls.cpp
+++ b/tools/verify_bls.cpp
@@ -24,10 +24,10 @@
 
 #include <bls/BLSPublicKey.h>
 #include <bls/bls.h>
+#include <tools/utils.h>
 #include <boost/program_options.hpp>
 #include <fstream>
 #include <third_party/json.hpp>
-#include <tools/utils.h>
 
 #define EXPAND_AS_STR( x ) __EXPAND_AS_STR__( x )
 #define __EXPAND_AS_STR__( x ) #x

--- a/tools/verify_bls.cpp
+++ b/tools/verify_bls.cpp
@@ -27,6 +27,7 @@
 #include <boost/program_options.hpp>
 #include <fstream>
 #include <third_party/json.hpp>
+#include <tools/utils.h>
 
 #define EXPAND_AS_STR( x ) __EXPAND_AS_STR__( x )
 #define __EXPAND_AS_STR__( x ) #x
@@ -36,33 +37,6 @@ static bool g_b_verbose_mode = false;
 static bool g_b_rehash = false;
 
 static bool g_b_common = true;
-
-int char2int( char _input ) {
-    if ( _input >= '0' && _input <= '9' )
-        return _input - '0';
-    if ( _input >= 'A' && _input <= 'F' )
-        return _input - 'A' + 10;
-    if ( _input >= 'a' && _input <= 'f' )
-        return _input - 'a' + 10;
-    return -1;
-}
-
-bool hex2carray( const char* _hex, uint64_t* _bin_len, uint8_t* _bin ) {
-    int len = strnlen( _hex, 2 * 1024 );
-
-    if ( len == 0 && len % 2 == 1 )
-        return false;
-    *_bin_len = len / 2;
-    for ( int i = 0; i < len / 2; i++ ) {
-        int high = char2int( ( char ) _hex[i * 2] );
-        int low = char2int( ( char ) _hex[i * 2 + 1] );
-        if ( high < 0 || low < 0 ) {
-            return false;
-        }
-        _bin[i] = ( unsigned char ) ( high * 16 + low );
-    }
-    return true;
-}
 
 void Verify( const size_t t, const size_t n, std::istream& sign_file, int j = -1 ) {
     libBLS::Bls bls_instance = libBLS::Bls( t, n );
@@ -92,7 +66,8 @@ void Verify( const size_t t, const size_t n, std::istream& sign_file, int j = -1
         }
     } else {
         uint64_t bin_len;
-        if ( !hex2carray( to_be_hashed.c_str(), &bin_len, hash_bytes_arr.data() ) ) {
+        if ( !libBLS::ThresholdUtils::hex2carray(
+                 to_be_hashed.c_str(), &bin_len, hash_bytes_arr.data(), hash_bytes_arr.size() ) ) {
             throw std::runtime_error( "Invalid hash" );
         }
     }


### PR DESCRIPTION
## Harden internal hex/RNG helpers against buffer overflow and silent RNG failure (#307)

Fixes a heap buffer overflow in `ThresholdUtils::hex2carray` and several unchecked `RAND_bytes` calls, plus removes duplicated unsafe hex-decoding code from the CLI tools.

### Changes

* **`hex2carray` bounds safety (CWE-787):** Added a `_bin_capacity` argument and now reject input whose decoded byte length doesn't exactly match the destination buffer. Added null-pointer guards and renamed `_bin_len` to `_bin_written_len` to clarify that it is an out-parameter. Updated all call sites in `bls.cpp`, `functions.cpp`, and `hash_g1.cpp`.

* **Removed unsafe duplicates:** Deleted the local, unchecked `hex2carray`/`char2int` implementations in `sign_bls.cpp` and `verify_bls.cpp`. Both now call the hardened `ThresholdUtils::hex2carray` with the actual destination buffer size.

* **Exact-length hashing:** `hashToG1(const std::string&)` now requires `message.length() == HASH_SIZE * 2` instead of only enforcing an upper bound.

* **Checked `RAND_bytes` failures (CWE-252):** Added failure handling in `AesGcmCipher.cpp` for random IV generation, `CipheredKey.cpp` for `random()`, and the test helpers in `utils.cpp` / `utils.h`.

* **Test fix:** `rand32HexStr()` generated only 32 hex characters (16 bytes) despite its name. It now generates 64 hex characters (32 bytes) to match `HASH_SIZE` in `test_bls.cpp` and `unit_tests_bls.cpp`. This was the root cause of the `blsAggregatedSignatures` regression after introducing the strict length check.

### Impact

* No public API break except for the new required `_bin_capacity` parameter on `hex2carray`.
* Callers passing malformed or incorrectly sized hex input now receive a clean `false`/exception instead of causing an out-of-bounds write.

### Notes

Follow-up security items, including subgroup validation on G2 shares, TE signer-index validation, and FFI exception safety, are tracked separately in `security-audit-2026-08-11.md` and are outside the scope of this PR.

Fixes #307 