### PR TITLE
set test hash to 32 bytes

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,5 +1,16 @@
 name: clang-format Check
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - develop
+      - beta
+      - stable
+  push:
+    branches:
+      - develop
+      - master
+      - beta
+      - stable
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/scripts/run_tools_test.sh
+++ b/scripts/run_tools_test.sh
@@ -10,7 +10,7 @@ cd "$WORK_DIR"
 
 DATA_FILE=data.txt
 SIGNATURE_FILE=signature.txt
-RANDOM_HASH_STR="9ebe2b024baa072bb02f1df851a88900"
+RANDOM_HASH_STR="9ebe2b024baa072bb02f1df851a889009ebe2b024baa072bb02f1df851a88900"
 
 calculate_hash() {
     HASH_FILE=hash.json


### PR DESCRIPTION
## Description

- Set test hash to 32 bytes to fix failing test in heavy tests workflow
- update clang format to run only for PRs to main branches